### PR TITLE
Force Camel version with project version to be aligned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <spring-boot-version>2.2.5.RELEASE</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>3.3.0-SNAPSHOT</camel-version>
+        <camel-version>${project.version}</camel-version>
 
         <!-- versions -->
         <!-- dependency versions -->


### PR DESCRIPTION
The Camel version used should be the same as the Camel-Karaf project, so it would be more easy to force it to `${project.version}`.