### PR TITLE
opentelemetry-context-prop was merged with opentelemetry-context on o…

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1999,7 +1999,7 @@
     <feature version='${project.version}'>camel-grpc</feature>
     <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry-version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-sdk/${opentelemetry-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context-prop/${opentelemetry-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-opentelemetry/${project.version}</bundle>
   </feature>
   <feature name='camel-paho' version='${project.version}' start-level='50'>


### PR DESCRIPTION
…tel 0.11

This is part of an effort to update camel to use opentelemetry 0.11 and depends on https://github.com/apache/camel/pull/4684

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>