### PR TITLE
CAMEL-16259 - Karaf examples expect org.apache.camel.component.servlet.osgi package

### DIFF
--- a/components/camel-servlet-osgi/src/main/java/org/apache/camel/component/servlet/osgi/OsgiServletRegisterer.java
+++ b/components/camel-servlet-osgi/src/main/java/org/apache/camel/component/servlet/osgi/OsgiServletRegisterer.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.component.osgi;
+package org.apache.camel.component.servlet.osgi;
 
 import java.util.Dictionary;
 import java.util.Hashtable;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CAMEL-16259

I believe this package name was a typo when migrating the code to camel-karaf. Downstream karaf-examples rely on org.apache.camel.component.servlet.osgi.* package.