### PR TITLE
Remove dependency=true to install bundle

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1307,7 +1307,7 @@
     <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-codec-api/2.0.0</bundle>
     <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-util/2.0.0</bundle>
     <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-model/2.0.0</bundle>
-    <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-net-mina/2.0.0</bundle>
+    <bundle>mvn:org.apache.directory.api/api-ldap-net-mina/2.0.0</bundle>
     <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-schema-data/2.0.0</bundle>
     <bundle dependency='true'>mvn:org.apache.directory.api/api-util/2.0.0</bundle>
     <bundle dependency='true'>mvn:org.apache.directory.server/apacheds-core-api/${apacheds-version}</bundle>


### PR DESCRIPTION
with dependency='true' the bundle is not installed automatically during a `feature:install camel-ldif`, by removing it is automatically installed as expected