### PR TITLE
Camel karaf 3.11.x Correct link generation

### DIFF
--- a/components/camel-bean-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-bean-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=bean-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-bean-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Bean
 projectDescription=Camel Bean component

--- a/components/camel-bean-osgi/src/generated/resources/bean-osgi.json
+++ b/components/camel-bean-osgi/src/generated/resources/bean-osgi.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-bean-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-bean-validator-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-bean-validator-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=bean-validator-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-bean-validator-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Bean Validator
 projectDescription=Camel bean validation support (JSR 303)

--- a/components/camel-bean-validator-osgi/src/generated/resources/bean-validator-osgi.json
+++ b/components/camel-bean-validator-osgi/src/generated/resources/bean-validator-osgi.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-bean-validator-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-blueprint-main/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-blueprint-main/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=blueprint-main
 groupId=org.apache.camel.karaf
 artifactId=camel-blueprint-main
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Blueprint Main
 projectDescription=Main support for OSGi Blueprint

--- a/components/camel-blueprint-main/src/generated/resources/blueprint-main.json
+++ b/components/camel-blueprint-main/src/generated/resources/blueprint-main.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-blueprint-main",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=blueprint
 groupId=org.apache.camel.karaf
 artifactId=camel-blueprint
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Blueprint
 projectDescription=Using Camel with OSGi Blueprint

--- a/components/camel-blueprint/src/generated/resources/blueprint.json
+++ b/components/camel-blueprint/src/generated/resources/blueprint.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-blueprint",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-cmis-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-cmis-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=cmis-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-cmis-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: CMIS
 projectDescription=Camel CMIS which is based on Apache Chemistry support

--- a/components/camel-cmis-osgi/src/generated/resources/cmis-osgi.json
+++ b/components/camel-cmis-osgi/src/generated/resources/cmis-osgi.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-cmis-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-cxf-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-cxf-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=cxf-blueprint
 groupId=org.apache.camel.karaf
 artifactId=camel-cxf-blueprint
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: CXF Blueprint
 projectDescription=Camel CXF for OSGi Blueprint

--- a/components/camel-cxf-blueprint/src/generated/resources/cxf-blueprint.json
+++ b/components/camel-cxf-blueprint/src/generated/resources/cxf-blueprint.json
@@ -9,6 +9,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-cxf-blueprint",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-cxf-transport-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-cxf-transport-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=cxf-transport-blueprint
 groupId=org.apache.camel.karaf
 artifactId=camel-cxf-transport-blueprint
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: CXF Transport Blueprint
 projectDescription=Camel CXF Transport for OSGi Blueprint

--- a/components/camel-cxf-transport-blueprint/src/generated/resources/cxf-transport-blueprint.json
+++ b/components/camel-cxf-transport-blueprint/src/generated/resources/cxf-transport-blueprint.json
@@ -9,6 +9,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-cxf-transport-blueprint",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-eventadmin/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/components/camel-eventadmin/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -2,6 +2,6 @@
 components=eventadmin
 groupId=org.apache.camel.karaf
 artifactId=camel-eventadmin
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Event Admin
 projectDescription=Camel Karaf OSGi Event Admin support

--- a/components/camel-eventadmin/src/generated/resources/org/apache/camel/component/eventadmin/eventadmin.json
+++ b/components/camel-eventadmin/src/generated/resources/org/apache/camel/component/eventadmin/eventadmin.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-eventadmin",
-    "version": "3.11.1-SNAPSHOT",
+    "version": "3.11.3-SNAPSHOT",
     "scheme": "eventadmin",
     "extendsScheme": "",
     "syntax": "eventadmin:topic",

--- a/components/camel-jcache-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-jcache-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=jcache-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-jcache-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: JCache
 projectDescription=Camel JCache support

--- a/components/camel-jcache-osgi/src/generated/resources/jcache-osgi.json
+++ b/components/camel-jcache-osgi/src/generated/resources/jcache-osgi.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-jcache-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-kura/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-kura/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=kura
 groupId=org.apache.camel.karaf
 artifactId=camel-kura
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Kura
 projectDescription=Using Camel with Eclipse Kura (OSGi)

--- a/components/camel-kura/src/generated/resources/kura.json
+++ b/components/camel-kura/src/generated/resources/kura.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-kura",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-osgi-activator/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-osgi-activator/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=osgi-activator
 groupId=org.apache.camel.karaf
 artifactId=camel-osgi-activator
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: OSGi Activator (deprecated)
 projectDescription=Camel OSGi Activator for running Camel routes from other bundles

--- a/components/camel-osgi-activator/src/generated/resources/osgi-activator.json
+++ b/components/camel-osgi-activator/src/generated/resources/osgi-activator.json
@@ -9,6 +9,6 @@
     "supportLevel": "Preview",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-osgi-activator",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-paxlogging/src/generated/resources/META-INF/services/org/apache/camel/component.properties
+++ b/components/camel-paxlogging/src/generated/resources/META-INF/services/org/apache/camel/component.properties
@@ -2,6 +2,6 @@
 components=paxlogging
 groupId=org.apache.camel.karaf
 artifactId=camel-paxlogging
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Pax Logging
 projectDescription=Camel OSGi Pax Logging support

--- a/components/camel-paxlogging/src/generated/resources/org/apache/camel/component/paxlogging/paxlogging.json
+++ b/components/camel-paxlogging/src/generated/resources/org/apache/camel/component/paxlogging/paxlogging.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-paxlogging",
-    "version": "3.11.1-SNAPSHOT",
+    "version": "3.11.3-SNAPSHOT",
     "scheme": "paxlogging",
     "extendsScheme": "",
     "syntax": "paxlogging:appender",

--- a/components/camel-servlet-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-servlet-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=servlet-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-servlet-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Servlet OSGi
 projectDescription=Camel Servlet for OSGi

--- a/components/camel-servlet-osgi/src/generated/resources/servlet-osgi.json
+++ b/components/camel-servlet-osgi/src/generated/resources/servlet-osgi.json
@@ -9,6 +9,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-servlet-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-test-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-test-blueprint/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=test-blueprint
 groupId=org.apache.camel.karaf
 artifactId=camel-test-blueprint
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Test :: Blueprint
 projectDescription=Camel unit testing with OSGi Blueprint

--- a/components/camel-test-blueprint/src/generated/resources/test-blueprint.json
+++ b/components/camel-test-blueprint/src/generated/resources/test-blueprint.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-test-blueprint",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-test-karaf/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-test-karaf/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=test-karaf
 groupId=org.apache.camel.karaf
 artifactId=camel-test-karaf
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Test :: Karaf
 projectDescription=Camel integration testing with Apache Karaf

--- a/components/camel-test-karaf/src/generated/resources/test-karaf.json
+++ b/components/camel-test-karaf/src/generated/resources/test-karaf.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-test-karaf",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/components/camel-zookeeper-master-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
+++ b/components/camel-zookeeper-master-osgi/src/generated/resources/META-INF/services/org/apache/camel/other.properties
@@ -2,6 +2,6 @@
 name=zookeeper-master-osgi
 groupId=org.apache.camel.karaf
 artifactId=camel-zookeeper-master-osgi
-version=3.11.1-SNAPSHOT
+version=3.11.3-SNAPSHOT
 projectName=Camel Karaf :: Zookeeper Master
 projectDescription=Camel Zookeeper Master Support

--- a/components/camel-zookeeper-master-osgi/src/generated/resources/zookeeper-master-osgi.json
+++ b/components/camel-zookeeper-master-osgi/src/generated/resources/zookeeper-master-osgi.json
@@ -10,6 +10,6 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-zookeeper-master-osgi",
-    "version": "3.11.1-SNAPSHOT"
+    "version": "3.11.3-SNAPSHOT"
   }
 }

--- a/docs/modules/ROOT/pages/components.adoc
+++ b/docs/modules/ROOT/pages/components.adoc
@@ -353,10 +353,10 @@ Number of Camel components: 183 in 183 JAR artifacts (1 deprecated)
 | xref:3.11.x@components::olingo4-component.adoc[Olingo4] (camel-olingo4) +
 `olingo4:apiName/methodName` | 2.19 | Communicate with OData 4.0 services using Apache Olingo OData API.
 
-| xref:3.11.x@camel-karaf::eventadmin-component.adoc[OSGi EventAdmin] (camel-eventadmin) +
+| xref:eventadmin-component.adoc[OSGi EventAdmin] (camel-eventadmin) +
 `eventadmin:topic` | 2.6 | The eventadmin component can be used in an OSGi environment to receive OSGi EventAdmin events and process them.
 
-| xref:3.11.x@camel-karaf::paxlogging-component.adoc[OSGi PAX Logging] (camel-paxlogging) +
+| xref:paxlogging-component.adoc[OSGi PAX Logging] (camel-paxlogging) +
 `paxlogging:appender` | 2.6 | The paxlogging component can be used in an OSGi environment to receive PaxLogging events and process them.
 
 | xref:3.11.x@components::paho-component.adoc[Paho] (camel-paho) +
@@ -802,7 +802,7 @@ Number of miscellaneous extensions: 20 in 20 JAR artifacts (3 deprecated)
 | xref:3.11.x@components:others:aws-xray.adoc[AWS XRay] +
 (camel-aws-xray) | 2.21 | Distributed tracing using AWS XRay
 
-| xref:3.11.x@camel-karaf::blueprint.adoc[Blueprint] +
+| xref:blueprint.adoc[Blueprint] +
 (camel-blueprint) | 2.4 | Using Camel with OSGi Blueprint
 
 | xref:3.11.x@components:others:caffeine-lrucache.adoc[Caffeine Lrucache] +
@@ -817,7 +817,7 @@ Number of miscellaneous extensions: 20 in 20 JAR artifacts (3 deprecated)
 | xref:3.11.x@components:others:jasypt.adoc[Jasypt] +
 (camel-jasypt) | 2.5 | Security using Jasypt
 
-| xref:3.11.x@camel-karaf::kura.adoc[Kura] +
+| xref:kura.adoc[Kura] +
 (camel-kura) | 2.15 | Using Camel with Eclipse Kura (OSGi)
 
 | xref:3.11.x@components:others:leveldb.adoc[LevelDB] +
@@ -838,7 +838,7 @@ Number of miscellaneous extensions: 20 in 20 JAR artifacts (3 deprecated)
 | xref:3.11.x@components:others:opentracing.adoc[OpenTracing] +
 (camel-opentracing) | 2.19 | Distributed tracing using OpenTracing
 
-| xref:3.11.x@camel-karaf::osgi-activator.adoc[Osgi Activator] +
+| xref:osgi-activator.adoc[Osgi Activator] +
 (camel-osgi-activator) | 3.1 | *deprecated* Camel OSGi Activator for running Camel routes from other bundles
 
 | xref:3.11.x@components:others:reactor.adoc[Reactor] +

--- a/tooling/camel-karaf-docs-maven-plugin/src/main/java/org/apache/camel/karaf/maven/ExtMvelHelper.java
+++ b/tooling/camel-karaf-docs-maven-plugin/src/main/java/org/apache/camel/karaf/maven/ExtMvelHelper.java
@@ -27,6 +27,8 @@ import org.apache.camel.tooling.model.LanguageModel;
 
 public class ExtMvelHelper {
 
+    private final static String CAMEL_VERSION = "3.11.x";
+
     private final Path extensionsDocPath;
 
     public ExtMvelHelper(Path extensionsDocPath) {
@@ -49,23 +51,23 @@ public class ExtMvelHelper {
             final ComponentModel component = (ComponentModel) model;
             final String scheme = component.getScheme();
             if ("org.apache.camel.karaf".equals(component.getGroupId())) {
-                return String.format("xref:3.11.x@camel-karaf::%s-component.adoc", scheme);
+                return String.format("xref:%s-component.adoc", scheme);
             } else {
-                return String.format("xref:3.11.x@components::%s-component.adoc", scheme);
+                return String.format("xref:%s@components::%s-component.adoc", CAMEL_VERSION, scheme);
             }
         } else if (model instanceof DataFormatModel) {
-            return String.format("xref:3.11.x@components:dataformats:%s-dataformat.adoc",
-                    invokeGetter(model, "getName"));
+            return String.format("xref:%s@components:dataformats:%s-dataformat.adoc",
+                    CAMEL_VERSION, invokeGetter(model, "getName"));
         } else if (model instanceof LanguageModel) {
-            return String.format("xref:3.11.x@components:languages:%s-language.adoc",
-                    invokeGetter(model, "getName"));
+            return String.format("xref:%s@components:languages:%s-language.adoc",
+                    CAMEL_VERSION, invokeGetter(model, "getName"));
         } else if (model instanceof OtherModel) {
             final OtherModel other = (OtherModel) model;
             final String name = other.getName();
             if ("org.apache.camel.karaf".equals(other.getGroupId())) {
-                return String.format("xref:3.11.x@camel-karaf::%s.adoc", name);
+                return String.format("xref:%s.adoc", name);
             } else {
-                return String.format("xref:3.11.x@components:others:%s.adoc", name);
+                return String.format("xref:%s@components:others:%s.adoc", CAMEL_VERSION, name);
             }
         } else {
             return null;


### PR DESCRIPTION
This adjusts 3.11.x as if the draft instructions from https://github.com/apache/camel/pull/6215 had been followed. It makes link generation consistent with main.