### PR TITLE
Updating Junit to 4.13.2 to fix CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <json-smart-version>2.4.7</json-smart-version>
         <jt400-bundle-version>10.7_1</jt400-bundle-version>
         <juel-bundle-version>2.1.3_1</juel-bundle-version>
-        <junit-bundle-version>4.11_1</junit-bundle-version>
+        <junit-bundle-version>4.13.2_1</junit-bundle-version>
         <jzlib-bundle-version>1.1.3_2</jzlib-bundle-version>
         <kafka-bundle-version>3.0.0_1</kafka-bundle-version>
         <kxml2-bundle-version>2.3.0_3</kxml2-bundle-version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-15250