### PR TITLE
set up 3.15.x docs

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -17,9 +17,7 @@
 
 name: camel-karaf
 title: Camel Karaf
-version: next
-prerelease: true
-display_version: Next (Pre-release)
+version: 3.15.x
 nav:
 - modules/ROOT/nav.adoc
 

--- a/docs/source-map.yml
+++ b/docs/source-map.yml
@@ -21,5 +21,5 @@
         - url: 'https://github.com/apache/camel-karaf.git'
           mapped-url: './../camel-karaf'
           branches:
-            - branch: main
+            - branch: camel-karaf-3.15.x
               mapped-branch: HEAD


### PR DESCRIPTION
This is needed for docs for 3.15.x: there might be other changes that are appropriate (such as a full maven build??)