### PR TITLE
CAMEL-18183: Wrong bundle in the camel-azure-storage-datalake feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -432,7 +432,7 @@
     <bundle dependency='true'>mvn:org.ow2.asm/asm-commons/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-tree/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-util/${asm.bundle.version}</bundle>
-    <bundle>mvn:org.apache.camel/camel-azure-storage-blob/${project.version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-azure-storage-datalake/${project.version}</bundle>
   </feature>
   <feature name='camel-azure-storage-queue' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>


### PR DESCRIPTION
fixes [CAMEL-18183](https://issues.apache.org/jira/browse/CAMEL-18183)

## Motivation

There is a typo in the definition of the feature `camel-azure-storage-datalake` that refers `org.apache.camel/camel-azure-storage-blob` instead of `org.apache.camel/camel-azure-storage-datalake`.

## Modifications:

* Set the expected bundle

## Result:

The bundle is now correct as we can see below:
```
karaf@root()> feature:info camel-azure-storage-datalake
Feature camel-azure-storage-datalake 3.18.0.SNAPSHOT
Feature has no configuration
Feature has no configuration files
Feature depends on:
  camel-core 3.18.0-SNAPSHOT
Feature contains followed bundles:
  mvn:com.fasterxml.jackson.core/jackson-core/2.13.3
  mvn:com.fasterxml.jackson.core/jackson-databind/2.13.3
  mvn:com.fasterxml.jackson.core/jackson-annotations/2.13.3
  mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.13.3
  mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.13.3
  mvn:org.codehaus.woodstox/stax2-api/4.2
  mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.3
  mvn:org.reactivestreams/reactive-streams/1.0.3
  mvn:io.projectreactor/reactor-core/3.4.14
  mvn:commons-io/commons-io/2.11.0
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-core/1.16.0_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-common/12.12.0_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob/12.12.0_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob-changefeed/12.0.0-beta8_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-file-datalake/12.5.1_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-identity/1.5.0_1
  mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.opensaml/3.4.6_2
  mvn:com.google.code.findbugs/jsr305/3.0.2
  mvn:joda-time/joda-time/2.10.11
  mvn:com.google.guava/guava/28.2-jre
  mvn:com.google.guava/failureaccess/1.0.1
  mvn:io.dropwizard.metrics/metrics-core/3.2.6
  mvn:commons-codec/commons-codec/1.15
  mvn:org.apache.santuario/xmlsec/2.2.3
  mvn:org.apache.httpcomponents/httpcore-osgi/4.4.15
  mvn:org.apache.httpcomponents/httpclient-osgi/4.5.13
  mvn:javax.servlet/javax.servlet-api/3.1.0
  mvn:net.minidev/json-smart/2.4.7
  mvn:net.minidev/accessors-smart/2.4.7
  mvn:org.bouncycastle/bcprov-jdk18on/1.71
  mvn:org.bouncycastle/bcpkix-jdk18on/1.71
  mvn:org.bouncycastle/bcutil-jdk18on/1.71
  mvn:org.cryptacular/cryptacular/1.2.5
  mvn:org.ow2.asm/asm/8.0.1
  mvn:org.ow2.asm/asm-analysis/8.0.1
  mvn:org.ow2.asm/asm-commons/8.0.1
  mvn:org.ow2.asm/asm-tree/8.0.1
  mvn:org.ow2.asm/asm-util/8.0.1
  mvn:org.apache.camel/camel-azure-storage-datalake/3.18.0-SNAPSHOT
```