### PR TITLE
CAMEL-18183: Wrong bundle in the camel-azure-storage-datalake feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -393,7 +393,7 @@
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob/${azure-storage-blob-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob-changefeed/${azure-storage-blob-changefeed-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-file-datalake/${azure-storage-blob-datalake-bundle-version}</bundle>
-    <bundle>mvn:org.apache.camel/camel-azure-storage-blob/${project.version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-azure-storage-datalake/${project.version}</bundle>
   </feature>
   <feature name='camel-azure-storage-queue' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>


### PR DESCRIPTION
fixes [CAMEL-18183](https://issues.apache.org/jira/browse/CAMEL-18183) for 3.14

## Motivation

There is a typo in the definition of the feature `camel-azure-storage-datalake` that refers `org.apache.camel/camel-azure-storage-blob` instead of `org.apache.camel/camel-azure-storage-datalake`.

## Modifications:

* Set the expected bundle