### PR TITLE
Upgrade Google Cloud dependencies for libraries-bom 25.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,18 +169,18 @@
         <fop-bundle-version>2.7_1</fop-bundle-version>
         <generex-bundle-version>1.0.2_1</generex-bundle-version>
         <!-- These google properties align versions defined in com.google.cloud:libraries-bom used in camel -->
-        <google-api-services-bigquery>v2-rev20220326-1.32.1</google-api-services-bigquery>
-        <google-cloud-api-client-version>1.34.0</google-cloud-api-client-version>
-        <google-cloud-api-common-version>2.1.5</google-cloud-api-common-version>
-        <google-cloud-auth-library-version>1.6.0</google-cloud-auth-library-version>
-        <google-cloud-bigquery-version>2.10.10</google-cloud-bigquery-version>
-        <google-cloud-core-version>2.6.0</google-cloud-core-version>
-        <google-cloud-gax-version>2.16.0</google-cloud-gax-version>
-        <google-cloud-gax-httpjson-version>0.101.0</google-cloud-gax-httpjson-version>
-        <google-cloud-http-client-version>1.41.7</google-cloud-http-client-version>
+        <google-api-services-bigquery>v2-rev20220507-1.32.1</google-api-services-bigquery>
+        <google-cloud-api-client-version>1.34.1</google-cloud-api-client-version>
+        <google-cloud-api-common-version>2.2.0</google-cloud-api-common-version>
+        <google-cloud-auth-library-version>1.7.0</google-cloud-auth-library-version>
+        <google-cloud-bigquery-version>2.13.0</google-cloud-bigquery-version>
+        <google-cloud-core-version>2.7.1</google-cloud-core-version>
+        <google-cloud-gax-version>2.18.1</google-cloud-gax-version>
+        <google-cloud-gax-httpjson-version>0.103.1</google-cloud-gax-httpjson-version>
+        <google-cloud-http-client-version>1.41.8</google-cloud-http-client-version>
         <google-cloud-oauth-client-version>1.33.3</google-cloud-oauth-client-version>
         <google-cloud-common-protos-version>2.8.3</google-cloud-common-protos-version>
-        <google-cloud-iam-version>1.3.1</google-cloud-iam-version>
+        <google-cloud-iam-version>1.3.4</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.6.0</google-cloud-threetenbp-version>
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>
         <google-findbugs-annotations2-version>2.0.3</google-findbugs-annotations2-version>


### PR DESCRIPTION
Relates to https://github.com/apache/camel/pull/7959.