### PR TITLE
CAMEL-18344: Supporting camel "camel-google-pubsub" and "camel-grpc" OSGi deployment

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -999,6 +999,48 @@
     <bundle dependency='true'>wrap:mvn:org.threeten/threetenbp/${google-cloud-threetenbp-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-google-bigquery/${project.version}</bundle>
   </feature>
+  <feature name='camel-google-pubsub' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-cloud-pubsub/${google-cloud-pubsub-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${google-cloud-api-common-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/${google-cloud-common-protos-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-iam-v1/${google-proto-iam-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-pubsub-guava-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-gax-grpc/${google-gax-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.threeten/threetenbp/${google-cloud-threetenbp-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-cloud-pubsub-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-pubsub-perfmark-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-http-client/${google-http-client-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-cloud-pubsub-opencensus-api-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-pubsub-grpc-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.re2j/re2j/${re2j-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${netty-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-proto/${opencensus-proto-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${squareup-okhttp-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${squareup-okio-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bctls-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-google-pubsub/${project.version}</bundle>
+  </feature>
   <feature name='camel-grape' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:org.codehaus.groovy/groovy/${groovy-version}</bundle>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1011,11 +1011,11 @@
     <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
     <bundle dependency='true'>wrap:mvn:org.threeten/threetenbp/${google-cloud-threetenbp-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-cloud-pubsub-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-pubsub-perfmark-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-http-client/${google-http-client-bundle-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-cloud-pubsub-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-http-client-opencensus-api-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-pubsub-grpc-bundle-version}</bundle>
@@ -1236,6 +1236,9 @@
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclient-version}</bundle>
     <bundle dependency='true'>mvn:org.codehaus.jettison/jettison/${jettison-version}</bundle>
     <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-http-client-opencensus-api-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-http-client/${google-http-client-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${jira-guava-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.atlassian-jira-client/${atlassian-jira-client-bundle-version}</bundle>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1006,19 +1006,19 @@
     <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/${google-cloud-common-protos-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-iam-v1/${google-proto-iam-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-pubsub-guava-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-guava-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-gax-grpc/${google-gax-bundle-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
     <bundle dependency='true'>wrap:mvn:org.threeten/threetenbp/${google-cloud-threetenbp-version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-pubsub-perfmark-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-perfmark-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-http-client/${google-http-client-bundle-version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-http-client-opencensus-api-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-pubsub-grpc-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-grpc-bundle-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.google.re2j/re2j/${re2j-version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
@@ -1065,7 +1065,42 @@
     <bundle dependency='true'>wrap:mvn:io.krakens/java-grok/${java-grok-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-grok/${project.version}</bundle>
   </feature>
-
+  <feature name='camel-grpc' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <bundle dependency='true'>wrap:mvn:com.auth0/java-jwt/${grpc-java-jwt-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-grpc-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-guava-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/${google-cloud-common-protos-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.re2j/re2j/${re2j-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${squareup-okhttp-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-proto/${opencensus-proto-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-perfmark-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${squareup-okio-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bctls-jdk18on/${bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.javassist/javassist/${javassist-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${protobuf-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-grpc/${project.version}</bundle>
+  </feature>
 
   <feature name='camel-gson' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -181,15 +181,23 @@
         <google-cloud-http-client-version>1.41.8</google-cloud-http-client-version>
         <google-cloud-oauth-client-version>1.33.3</google-cloud-oauth-client-version>
         <google-cloud-common-protos-version>2.8.3</google-cloud-common-protos-version>
+        <google-cloud-pubsub-bundle-version>1.119.0_1-SNAPSHOT</google-cloud-pubsub-bundle-version>
+        <google-cloud-pubsub-grpc-bundle-version>1.48.0_2-SNAPSHOT</google-cloud-pubsub-grpc-bundle-version>
+        <google-cloud-pubsub-guava-bundle-version>31.1_1</google-cloud-pubsub-guava-bundle-version>
+        <google-cloud-pubsub-perfmark-version>0.25.0</google-cloud-pubsub-perfmark-version>
+        <google-cloud-pubsub-opencensus-api-version>0.31.1</google-cloud-pubsub-opencensus-api-version>
         <google-cloud-iam-version>1.3.4</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.6.0</google-cloud-threetenbp-version>
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>
         <google-findbugs-annotations2-version>2.0.3</google-findbugs-annotations2-version>
-        <google-http-client-bundle-version>1.41.8_1</google-http-client-bundle-version>
+        <google-gax-bundle-version>2.18.1_1-SNAPSHOT</google-gax-bundle-version>
+        <google-http-client-bundle-version>1.41.8_2-SNAPSHOT</google-http-client-bundle-version>
+        <google-proto-iam-version>1.3.4</google-proto-iam-version>
         <google-truth-version>0.30</google-truth-version>
         <groovy-version>3.0.8</groovy-version>
         <grpc-bundle-version>1.44.1_1</grpc-bundle-version>
         <grpc-errorprone-version>2.3.4</grpc-errorprone-version>
+        <grpc-google-auth-library-version>1.7.0</grpc-google-auth-library-version>
         <guice-bundle-version>3.0_1</guice-bundle-version>
         <hikaricp-version>2.4.13</hikaricp-version>
         <hk2-osgi-resource-version>1.0.1</hk2-osgi-resource-version>
@@ -250,6 +258,7 @@
         <olingo2-gson-version>2.4</olingo2-gson-version>
         <ognl-bundle-version>3.1.12_1</ognl-bundle-version>
         <opencensus-api-version>0.24.0</opencensus-api-version>
+        <opencensus-proto-version>0.2.0</opencensus-proto-version>
         <oncrpc-version>1.1.3</oncrpc-version>
         <ops4j-base-version>1.5.0</ops4j-base-version>
         <oro-bundle-version>2.0.8_6</oro-bundle-version>
@@ -262,9 +271,11 @@
         <perfmark-version>0.17.0</perfmark-version>
         <protobuf-guava-version>30.1.1-jre</protobuf-guava-version>
         <protobuf-javanano-version>3.1.0</protobuf-javanano-version>
+        <protobuf-version>3.21.4</protobuf-version>
         <reflections-bundle-version>0.9.12_1</reflections-bundle-version>
         <regexp-bundle-version>1.4_1</regexp-bundle-version>
         <rescu-version>2.1.0</rescu-version>
+        <re2j-version>1.5</re2j-version>
         <roaster-version>2.21.1.Final</roaster-version>
         <saxon-bundle-version>9.9.1-6_1</saxon-bundle-version>
         <scribe-bundle-version>1.3.7_1</scribe-bundle-version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,13 +185,13 @@
         <google-cloud-pubsub-grpc-bundle-version>1.48.0_2-SNAPSHOT</google-cloud-pubsub-grpc-bundle-version>
         <google-cloud-pubsub-guava-bundle-version>31.1_1</google-cloud-pubsub-guava-bundle-version>
         <google-cloud-pubsub-perfmark-version>0.25.0</google-cloud-pubsub-perfmark-version>
-        <google-cloud-pubsub-opencensus-api-version>0.31.1</google-cloud-pubsub-opencensus-api-version>
         <google-cloud-iam-version>1.3.4</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.6.0</google-cloud-threetenbp-version>
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>
         <google-findbugs-annotations2-version>2.0.3</google-findbugs-annotations2-version>
         <google-gax-bundle-version>2.18.1_1-SNAPSHOT</google-gax-bundle-version>
         <google-http-client-bundle-version>1.41.8_2-SNAPSHOT</google-http-client-bundle-version>
+        <google-http-client-opencensus-api-version>0.31.1</google-http-client-opencensus-api-version>
         <google-proto-iam-version>1.3.4</google-proto-iam-version>
         <google-truth-version>0.30</google-truth-version>
         <groovy-version>3.0.8</groovy-version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,19 +178,19 @@
         <google-cloud-core-version>2.7.1</google-cloud-core-version>
         <google-cloud-gax-version>2.18.1</google-cloud-gax-version>
         <google-cloud-gax-httpjson-version>0.103.1</google-cloud-gax-httpjson-version>
-        <google-cloud-grpc-bundle-version>1.48.0_2-SNAPSHOT</google-cloud-grpc-bundle-version>
+        <google-cloud-grpc-bundle-version>1.48.1_2</google-cloud-grpc-bundle-version>
         <google-cloud-guava-bundle-version>31.1_1</google-cloud-guava-bundle-version>
         <google-cloud-http-client-version>1.41.8</google-cloud-http-client-version>
         <google-cloud-oauth-client-version>1.33.3</google-cloud-oauth-client-version>
         <google-cloud-common-protos-version>2.8.3</google-cloud-common-protos-version>
         <google-cloud-perfmark-version>0.25.0</google-cloud-perfmark-version>
-        <google-cloud-pubsub-bundle-version>1.119.0_1-SNAPSHOT</google-cloud-pubsub-bundle-version>
+        <google-cloud-pubsub-bundle-version>1.119.0_1</google-cloud-pubsub-bundle-version>
         <google-cloud-iam-version>1.3.4</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.6.0</google-cloud-threetenbp-version>
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>
         <google-findbugs-annotations2-version>2.0.3</google-findbugs-annotations2-version>
-        <google-gax-bundle-version>2.18.1_1-SNAPSHOT</google-gax-bundle-version>
-        <google-http-client-bundle-version>1.41.8_2-SNAPSHOT</google-http-client-bundle-version>
+        <google-gax-bundle-version>2.18.1_1</google-gax-bundle-version>
+        <google-http-client-bundle-version>1.41.8_2</google-http-client-bundle-version>
         <google-http-client-opencensus-api-version>0.31.1</google-http-client-opencensus-api-version>
         <google-proto-iam-version>1.3.4</google-proto-iam-version>
         <google-truth-version>0.30</google-truth-version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,13 +178,13 @@
         <google-cloud-core-version>2.7.1</google-cloud-core-version>
         <google-cloud-gax-version>2.18.1</google-cloud-gax-version>
         <google-cloud-gax-httpjson-version>0.103.1</google-cloud-gax-httpjson-version>
+        <google-cloud-grpc-bundle-version>1.48.0_2-SNAPSHOT</google-cloud-grpc-bundle-version>
+        <google-cloud-guava-bundle-version>31.1_1</google-cloud-guava-bundle-version>
         <google-cloud-http-client-version>1.41.8</google-cloud-http-client-version>
         <google-cloud-oauth-client-version>1.33.3</google-cloud-oauth-client-version>
         <google-cloud-common-protos-version>2.8.3</google-cloud-common-protos-version>
+        <google-cloud-perfmark-version>0.25.0</google-cloud-perfmark-version>
         <google-cloud-pubsub-bundle-version>1.119.0_1-SNAPSHOT</google-cloud-pubsub-bundle-version>
-        <google-cloud-pubsub-grpc-bundle-version>1.48.0_2-SNAPSHOT</google-cloud-pubsub-grpc-bundle-version>
-        <google-cloud-pubsub-guava-bundle-version>31.1_1</google-cloud-pubsub-guava-bundle-version>
-        <google-cloud-pubsub-perfmark-version>0.25.0</google-cloud-pubsub-perfmark-version>
         <google-cloud-iam-version>1.3.4</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.6.0</google-cloud-threetenbp-version>
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18344

## Motivation

The features camel-google-pubsub and camel-grpc have been removed from camel-karaf due to some integrations issues but as some users need it, it is important to put them back.

## Modifications:

* Re-add the features
* Use new servicemix-bundles that still need to be approved, merged, and released
* Fix camel-jira feature that is affected by the changes in the bundle google-http-client