### PR TITLE
Remove deprecated ahc component from test

### DIFF
--- a/catalog/camel-catalog-provider-karaf/src/test/java/org/apache/camel/catalog/karaf/KarafRuntimeProviderTest.java
+++ b/catalog/camel-catalog-provider-karaf/src/test/java/org/apache/camel/catalog/karaf/KarafRuntimeProviderTest.java
@@ -69,7 +69,6 @@ public class KarafRuntimeProviderTest {
         assertTrue(names.contains("bean"));
 
         // regular components
-        assertTrue(names.contains("ahc"));
         assertTrue(names.contains("ftp"));
         assertTrue(names.contains("http"));
         assertTrue(names.contains("jetty"));


### PR DESCRIPTION
Trying to run the tests against 3.19.0-SNAPSHOT, it looks like camel-ahc has been removed? 

https://issues.apache.org/jira/browse/CAMEL-18496

Should it be removed from the tests?