### PR TITLE
CAMEL-16484: camel-dropbox - Bump to Dropbox 5.4.2

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -801,13 +801,8 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/${javax-servlet-api-version}</bundle>
     <bundle dependency='true'>mvn:com.dropbox.core/dropbox-core-sdk/${dropbox-version}</bundle>
-    <!-- sadly dropbox-core-sdk include test scoped dependencies in its MANIFEST.MF OSGi import
-         so we need a bunch of other bundles here -->
-    <bundle dependency='true'>wrap:mvn:com.google.android/android/4.1.1.4</bundle>
-    <bundle dependency='true'>wrap:mvn:com.google.appengine/appengine-api-1.0-sdk/1.9.38</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${squareup-okhttp-bundle-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${squareup-okio-bundle-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp/3.5.0</bundle>
+    <!-- Should not be required -->
+    <bundle dependency='true'>mvn:org.jetbrains.kotlin/kotlin-osgi-bundle/1.6.21</bundle>
     <bundle>mvn:org.apache.camel/camel-dropbox/${project.version}</bundle>
   </feature>
   <feature name='camel-ehcache' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-16484

## Motivation 

The version of Dropbox used is outdated (3.2.0) so it needs to be upgraded to the latest version.

## Modifications:

* Update consequently the list of dependencies