### PR TITLE
Upgrade stax2-api to 4.2.1 / Version 3.1.4 conflicting with cxf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <squareup-okhttp-bundle-version>2.7.5_1</squareup-okhttp-bundle-version>
         <squareup-okio-bundle-version>1.15.0_1</squareup-okio-bundle-version>
         <squareup-retrofit2-bundle-version>2.5.0_2</squareup-retrofit2-bundle-version>
-        <stax2-api-bundle-version>3.1.4</stax2-api-bundle-version>
+        <stax2-api-bundle-version>4.2.1</stax2-api-bundle-version>
         <stax2v4-api-bundle-version>4.2</stax2v4-api-bundle-version>
         <stringtemplate-bundle-version>4.3.4_1</stringtemplate-bundle-version>
         <tagsoup-bundle-version>1.2.1_1</tagsoup-bundle-version>


### PR DESCRIPTION
The features `cxf` and `camel-blueprint` provided by the feature-repos

mvn:org.apache.cxf.karaf/apache-cxf/3.5.2/xml/features, \
mvn:org.apache.camel.karaf/apache-camel/3.18.0/xml/features

cause jax-ws problems: Accessing some wsdl (e.g. /cxf/my-service?wsdl) gives following error:
java.lang.NoSuchMethodError: 'org.codehaus.stax2.ri.EmptyIterator org.codehaus.stax2.ri.EmptyIterator.getInstance()

As it turns out, following bundles are installed:

233 │ Active │ 20 │ 4.2.1 │ mvn:org.codehaus.woodstox/stax2-api/4.2.1 (installed by cxf)
318 │ Active │ 10 │ 3.1.4 │ mvn:org.codehaus.woodstox/stax2-api/3.1.4 (installed by camel-blueprint)

So, it seems like cxf is wired to the wrong version auf stax2-api. 

To upgrade the stax2-api to 4.2.1 fixes this issue