### PR TITLE
CAMEL-18775: Re-add the camel-spring-redis Karaf feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1822,6 +1822,23 @@
     <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-core/${micrometer-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-reactor/${project.version}</bundle>
   </feature>
+  <feature name='camel-spring-redis' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <feature version='${spring-version-range}'>spring-tx</feature>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-redis/${spring-data-redis-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-commons/${spring-data-commons-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-keyvalue/${spring-data-keyvalue-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jedis/${jedis-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.commons/commons-pool2/${commons-pool2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-spring-redis/${project.version}</bundle>
+  </feature>
   <feature name='camel-rest-openapi' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature version='${project.version}'>camel-http</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
         <jboss-logging-version>3.4.1.Final</jboss-logging-version>
         <jdom-bundle-version>2.0.6_1</jdom-bundle-version>
         <jira-guava-bundle-version>30.1.1_1</jira-guava-bundle-version>
+        <jedis-bundle-version>3.7.0_1</jedis-bundle-version>
         <jetty9-version>9.4.32.v20200930</jetty9-version>
         <jodatime-bundle-version>1.6.2</jodatime-bundle-version>
         <jolt-bundle-version>0.1.6_1</jolt-bundle-version>
@@ -287,6 +288,8 @@
         <solr-bundle-version>8.11.1_1</solr-bundle-version>
         <spring-batch-bundle-version>4.3.7_1</spring-batch-bundle-version>
         <spring-data-commons-bundle-version>2.6.2_1</spring-data-commons-bundle-version>
+        <spring-data-keyvalue-bundle-version>2.6.2_1</spring-data-keyvalue-bundle-version>
+        <spring-data-redis-bundle-version>2.6.2_1</spring-data-redis-bundle-version>
         <spring-ldap-bundle-version>2.3.7.RELEASE_1</spring-ldap-bundle-version>
         <spring-ws-bundle-version>3.0.8.RELEASE_1</spring-ws-bundle-version>
         <spring-xml-bundle-version>3.0.7.RELEASE_1</spring-xml-bundle-version>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18775

## Motivation

The "camel-spring-redis" Karaf feature has been removed from Camel Karaf since version 3.8.0, which has the consequence of preventing Camel/Karaf users from accessing Redis.

## Modifications:

* Add the feature `camel-spring-redis` to the existing ones
* Set the version of the bundles in the main pom file 