### PR TITLE
CAMEL-18781: Re-add the camel-mongodb and camel-mongodb-gridfs features

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1594,6 +1594,26 @@
     <feature version='${project.version}'>camel-core</feature>
     <bundle>mvn:org.apache.camel/camel-mllp/${project.version}</bundle>
   </feature>
+  <feature name='camel-mongodb' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <feature version='${project.version}'>camel-jackson</feature>
+    <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
+    <feature prerequisite='true'>wrap</feature>
+    <!-- Temporary workaround to fix https://jira.mongodb.org/browse/JAVA-4789, won't be needed once 4.8.0 will be released -->
+    <bundle dependency='true'>wrap:mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-mongodb/${project.version}</bundle>
+  </feature>
+  <feature name='camel-mongodb-gridfs' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <feature version='${project.version}'>camel-jackson</feature>
+    <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
+    <feature prerequisite='true'>wrap</feature>
+    <!-- Temporary workaround to fix https://jira.mongodb.org/browse/JAVA-4789, won't be needed once 4.8.0 will be released -->
+    <bundle dependency='true'>wrap:mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
+    <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-mongodb-gridfs/${project.version}</bundle>
+  </feature>
   <feature name='camel-mustache' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-bundle-version}</bundle>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18781

## Motivation

The "camel-mongodb" and "camel-mongodb-gridfs" Karaf features have been removed from Camel Karaf since version 3.16.0, which has the consequence of preventing Camel/Karaf users from accessing MongoDB.

## Modifications:

* Add the features `camel-spring-mongodb` and `camel-mongodb-gridfs` to the existing ones
* Add a comment about the temporary fix for https://jira.mongodb.org/browse/JAVA-4789