### PR TITLE
Fix dependency issues in the feature camel-jsonata

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1318,11 +1318,12 @@
   <feature name='camel-jsonata' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>wrap:mvn:com.ibm.jsonata4java/JSONata4Java/${jsonata4java-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.antlr/antlr4-runtime/${antlr-runtime-v4-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.antlr/antlr4-runtime/4.11.1</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
-    <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.code.gson/gson/2.10</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-text/${commons-text-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-jsonata/${project.version}</bundle>


### PR DESCRIPTION
## Motivation

The build is failing due to dependency issues in the feature `camel-jsonata` that need to be addressed

## Modifications:

* Add the new required dependency `jackson-dataformat-xml`
* Upgrade `antlr4-runtime` and `gson` to the versions expected by the new version of `JSONata4Java`
