### PR TITLE
CAMEL-18787: Add the camel-elasticsearch Karaf feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -809,6 +809,23 @@
     <bundle dependency="true">mvn:org.ehcache/ehcache/${ehcache3-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-ehcache/${project.version}</bundle>
   </feature>
+  <feature name='camel-elasticsearch' version='${project.version}' start-level='50'>
+    <feature version="${project.version}">camel-core</feature>
+    <feature prerequisite='true'>wrap</feature>
+    <bundle dependency='true'>wrap:mvn:co.elastic.clients/elasticsearch-java/${elasticsearch-java-client-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/${elasticsearch-java-client-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclient-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client-sniffer/${elasticsearch-java-client-sniffer-version}</bundle>
+    <bundle dependency='true'>mvn:jakarta.json/jakarta.json-api/2.0.1</bundle>
+    <bundle dependency='true'>mvn:org.eclipse.parsson/parsson/1.0.0</bundle>
+    <bundle dependency='true'>mvn:org.glassfish/jakarta.json/2.0.1</bundle>
+    <bundle>mvn:org.apache.camel/camel-elasticsearch/${project.version}</bundle>
+  </feature>
   <feature name='camel-elasticsearch-rest' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <feature>http</feature>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CAMEL-18787

## Motivation

The new component `camel-elasticsearch` has been added to Camel 3.19 and needs to be added to Camel Karaf too.

## Modifications:

* Add the feature `camel-elasticsearch` to the existing ones