### PR TITLE
CAMEL-18787: Use the elasticsearch-java ServiceMix bundle

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -812,8 +812,7 @@
   <feature name='camel-elasticsearch' version='${project.version}' start-level='50'>
     <feature version="${project.version}">camel-core</feature>
     <feature prerequisite='true'>wrap</feature>
-    <bundle dependency='true'>wrap:mvn:co.elastic.clients/elasticsearch-java/${elasticsearch-java-client-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/${elasticsearch-java-client-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch-java/${elasticsearch-java-bundle-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
         <docker-java-bundle-version>3.2.12_1</docker-java-bundle-version>
         <docker-java-commons-compress-version>1.21</docker-java-commons-compress-version>
         <egit-github-core-bundle-version>2.1.5_1</egit-github-core-bundle-version>
+        <elasticsearch-java-bundle-version>8.5.2_1</elasticsearch-java-bundle-version>
         <elasticsearch-rest-bundle-version>7.9.0_1</elasticsearch-rest-bundle-version>
         <eddsa-version>0.3.0</eddsa-version>
         <facebook4j-core-bundle-version>2.4.13_1</facebook4j-core-bundle-version>


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-18787

## Motivation

A dedicated ServiceMix bundle `elasticsearch-java` has been released and should be used for the sake of simplicity

## Modifications:

* Replace the wrapped libs that are directly related to `elasticsearch-java` with the corresponding ServiceMix bundle
* Add the version of the bundle in the parent pom file