### PR TITLE
CAMEL-19388: OSGI - Allow to use CXF 3.6+

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -18,7 +18,7 @@
 
 -->
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.5.0" name='camel-${project.version}'>
-  <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf-version}/xml/features</repository>
+  <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf-version-range}/xml/features</repository>
   <repository>mvn:org.ops4j.pax.cdi/pax-cdi-features/[1,2)/xml/features</repository>
 
   <feature name='xml-specs-api' version='${servicemix-specs-version}' start-level='10'>


### PR DESCRIPTION
## Motivation

Since Apache Camel 3.20 is an LTS version and CXF 3.5 should not be maintained anymore soon as 3.6 and 4.0 have been released, the goal of this task is to extend the version range of CXF to allow OSGI users to choose a higher version of CXF 3 that will remain backward compatible with CXF 3.5.

## Modifications:

* Uses a range of versions for the CXF repository