### PR TITLE
[CAMEL-19323] Camel Karaf 3.2X Saxon HE 11.5 Dependency Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <rescu-version>2.1.0</rescu-version>
         <re2j-version>1.5</re2j-version>
         <roaster-version>2.21.1.Final</roaster-version>
-        <saxon-bundle-version>11.4_1</saxon-bundle-version>
+        <saxon-bundle-version>11.5_1</saxon-bundle-version>
         <scribe-bundle-version>1.3.7_1</scribe-bundle-version>
         <serp-bundle-version>1.14.1_1</serp-bundle-version>
         <servicemix-jaxb-version>2.3_2</servicemix-jaxb-version>
@@ -313,7 +313,7 @@
         <xalan-bundle-version>2.7.2_3</xalan-bundle-version>
         <xerces-bundle-version>2.12.0_1</xerces-bundle-version>
         <xmlgraphics-commons-bundle-version>2.3_1</xmlgraphics-commons-bundle-version>
-        <xmlresolver-bundle-version>1.2_5</xmlresolver-bundle-version>
+        <xmlresolver-bundle-version>4.6.4_2</xmlresolver-bundle-version>
         <xpp3-bundle-version>1.1.4c_7</xpp3-bundle-version>
         <xstream-bundle-version>1.4.19_1</xstream-bundle-version>
         <zipkin-libthrift-version>0.13.0</zipkin-libthrift-version>


### PR DESCRIPTION
Issue - https://issues.apache.org/jira/browse/CAMEL-19323
More information is in the ticket.

Upgraded Camel Karaf Saxon HE 11.5 and XMLResolver 4.6.4 to sync Camel compile time and runtime in Karaf.