### PR TITLE
CAMEL-19984: Re-add Camel-Cassandraql Karaf feature

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -574,6 +574,30 @@
     <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeine-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-caffeine-lrucache/${project.version}</bundle>
   </feature>
+  <feature name='camel-cassandraql' version='${project.version}' start-level='50'>
+    <feature version='${project.version}'>camel-core</feature>
+    <bundle dependency='true'>mvn:com.datastax.oss/java-driver-shaded-guava/${cassandra-shaded-guava}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
+    <!-- need older metrics version -->
+    <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${cassandra-metrics-version}</bundle>
+    <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-json/${cassandra-metrics-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${cassandra-jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${cassandra-jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${cassandra-jackson2-version}</bundle>
+    <bundle dependency='true'>mvn:com.datastax.oss/java-driver-core/${cassandra-driver-version}</bundle>
+    <bundle dependency='true'>mvn:com.datastax.oss/java-driver-query-builder/${cassandra-driver-version}</bundle>
+    <bundle dependency='true'>mvn:com.typesafe/config/${typesafe-config}</bundle>
+    <bundle dependency='true'>mvn:org.hdrhistogram/HdrHistogram/${hdrhistrogram-version}</bundle>
+    <bundle dependency='true'>mvn:com.datastax.oss/native-protocol/${datastax-native-protocol}</bundle>
+    <bundle>mvn:org.apache.camel/camel-cassandraql/${project.version}</bundle>
+  </feature>  
   <feature name='camel-cbor' version='${project.version}' start-level='50'>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,15 @@
         <braintree-jackson2-version>2.12.3</braintree-jackson2-version>
         <build-helper-maven-plugin-version>1.12</build-helper-maven-plugin-version>
         <c3p0-bundle-version>0.9.5.5_1</c3p0-bundle-version>
+        <cassandra-jackson2-version>2.13.2</cassandra-jackson2-version>
+        <cassandra-metrics-version>4.1.18</cassandra-metrics-version>
+        <cassandra-shaded-guava>25.1-jre-graal-sub-1</cassandra-shaded-guava>
         <chunk-templates-bundle-version>3.6.2_1</chunk-templates-bundle-version>
         <classmate-version>1.5.1</classmate-version>
         <cometd-java-server-bundle-version>2.3.1_2</cometd-java-server-bundle-version>
         <commons-httpclient-bundle-version>3.1_7</commons-httpclient-bundle-version>
         <consul-client-bundle-version>1.3.3_1</consul-client-bundle-version>
-        <datastax-native-protocol>1.4.10</datastax-native-protocol>
+        <datastax-native-protocol>1.5.1</datastax-native-protocol>
         <digitalocean-api-client-bundle-version>2.17_1</digitalocean-api-client-bundle-version>
         <digitalpetri-fsm-client>0.2</digitalpetri-fsm-client>
         <digitalpetri-netty-client>0.3</digitalpetri-netty-client>


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19984 for 3.21

## Motivation

The feature was removed by https://issues.apache.org/jira/browse/CAMEL-16422 due to a DSE import package that was missing because the artifact `native-protocol` did not export the version expected by `java-driver-core`, it is no longer the case so it can be added back

## Modifications

* Restore the feature `camel-cassandraql` as it was in 3.9.0
* Set the version of the dependencies corresponding to the version of `java-driver-core` used