### PR TITLE
Ref#271: Add missing bundles for camel-amqp and camel-activemq

### DIFF
--- a/components/camel-activemq/pom.xml
+++ b/components/camel-activemq/pom.xml
@@ -37,15 +37,9 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.import>
-            !org.apache.activemq*,
-            !org.fusesource.hawtbuf,
             com.thoughtworks.xstream*;resolution:=optional,
             *
         </camel.osgi.import>
-        <camel.osgi.private>
-            org.apache.activemq*,
-            org.fusesource.hawtbuf
-        </camel.osgi.private>
     </properties>
 
     <dependencies>

--- a/components/camel-amqp/pom.xml
+++ b/components/camel-amqp/pom.xml
@@ -37,12 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.import>
-            !org.apache.qpid*,
             *
         </camel.osgi.import>
-        <camel.osg.private>
-            org.apache.qpid*
-        </camel.osg.private>
     </properties>
 
     <dependencies>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -285,11 +285,18 @@
 
     <feature name='camel-activemq' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-jms</feature>
+        <bundle dependency='true'>mvn:org.apache.activemq/activemq-client-jakarta/${activemq-version}</bundle>
+        <bundle dependency='true'>mvn:org.fusesource.hawtbuf/hawtbuf/1.11</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-activemq/${project.version}</bundle>
     </feature>
 
     <feature name='camel-amqp' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-jms</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle dependency='true'>mvn:org.apache.qpid/qpid-jms-client/${qpid-jms-client-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.qpid/proton-j/${qpid-proton-j-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-amqp/${project.version}</bundle>
     </feature>
 
@@ -1237,6 +1244,16 @@
     <feature name="camel-jms" version="${project.version}" start-level="50">
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version="${camel.osgi.spring.version}">spring-jms</feature>
+        <!-- The SMX bundle of Spring JMS doesn't contain micrometer as part of its import packages, see https://issues.apache.org/jira/browse/SM-5706,
+            so we need to override the imports by wrapping the bundle until it is fixed in the SMX bundle project and in Karaf.
+            The Bundle-Version is updated by Bundle-Version=${spring-version}.2 so that the updated bundle is used
+            instead of the one provided by Karaf.
+        -->
+        <!-- Workaround START -->
+        <bundle start-level="30">wrap:mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-jms/${spring-version}_1$overwrite=merge&amp;Import-package=io.micrometer;resolution:=optional,*;resolution:=optional&amp;Bundle-Version=${spring-version}.2</bundle>
+        <!-- Workaround END -->
+        <bundle dependency='true'>mvn:io.micrometer/micrometer-observation/${micrometer-version}</bundle>
+        <bundle dependency='true'>mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jms/${project.version}</bundle>
     </feature>
     <feature name='camel-jmx' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/271

### Motivation
During testing using an OSGI blueprint, it turned out that the camel-amqp and camel-activemq are missing bundles to successfully execute the route. Since these two features both and the only ones that depend upon camel-jms, and the micrometer dependency should be added to camel-jms, the fixes for both features are united in a single PR.

### Modifications:
Add a workaround for spring-jms SMX bundle to contain micrometer until https://issues.apache.org/jira/browse/SM-5706 is resolved and released
Add missing bundles for both features to run

**camel-amqp** was tested with
```
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
           xsi:schemaLocation="
             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">

    <bean id="amqpConnectionDetails" class="org.apache.camel.component.amqp.AMQPConnectionDetails">
        <argument value="amqp://localhost:5672"/>
    </bean>


    <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/blueprint">
        <route id="amqpRoute">
            <from uri="timer://testTimer?fixedRate=true&amp;period=5000"/>
            <setHeader name="theHeader">
                <constant>This is header</constant>
            </setHeader>
            <setBody>
                <constant>Hello Camel</constant>
            </setBody>
            <to uri="amqp:amqpQueueName"/>
            <log message="Message sent to AMQP: ${body} headers ${header.theHeader}"/>
        </route>

        <route id="amqpRoute2">
            <from uri="amqp:amqpQueueName"/>
            <log message="Message received from AMQP: ${body} headers ${header.theHeader}"/>
            <choice>
                <when>
                    <simple>${header.theHeader} != "This is header"</simple>
                    <log message="KO - not expected ${header.theHeader}"/>
                    <throwException exceptionType="java.lang.Exception" message="An unexpected header returned"/>
                </when>
                <otherwise>
                    <log message="OK - expected ${header.theHeader}"/>
                    
                </otherwise>
            </choice>
            <choice>
                <when>
                    <simple>${body} != "Hello Camel"</simple>
                    <log message="KO - not expected ${body}"/>
                    <throwException exceptionType="java.lang.Exception" message="An unexpected body returned"/>
                </when>
                <otherwise>
                    <log message="OK - expected ${body}"/>
                </otherwise>
            </choice>
        </route>

    </camelContext>

</blueprint>
```
To run the Docker container for the route execute:
`docker run -d --name test_rabbitmq -p 5672:5672 rabbitmq:3.13.1`
and enable the amqp plugin in the container's console
`rabbitmq-plugins enable rabbitmq_amqp1_0 `

**camel-activemq** was tested with
```
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
           xsi:schemaLocation="
             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">


    <bean id="activemqConfig" class="org.apache.camel.component.activemq.ActiveMQConfiguration">
        <property name="connectionFactory" ref="activemqConnectionFactory"/>
    </bean>

     <bean id="activemqConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
        <argument value="tcp://localhost:61616"/>
        <property name="watchTopicAdvisories" value="false"/>
                <property name="userName" value="myUser"/>
        <property name="password" value="myPassword"/> 
    </bean>

    <bean id="activemq" class="org.apache.camel.component.activemq.ActiveMQComponent">
        <property name="configuration" ref="activemqConfig"/>
    </bean>

    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
        <route id="activeMqProducerRoute">
            <from uri="timer://myTimer?fixedRate=true&amp;period=5000"/>
            <setBody>
                <simple>Hello Camel</simple>
            </setBody>
            <log message="Sending message to ActiveMQ: ${body}"/>
            <to uri="activemq:queue:activemqQueueName"/>
            <log message="Message sent to ActiveMQ: ${body}"/>
        </route>
        <route id="activeMqConsumerRoute">
        <from uri="activemq:queue:activemqQueueName"/>
        <log message="Message received from ActiveMQ: ${body}"/>
        </route>
    </camelContext>

</blueprint>
```
to run the Docker container for the route execute
```
docker run -d --name activemq-container-classic \
  -e ACTIVEMQ_USERNAME=myUser \
  -e ACTIVEMQ_PASSWORD=myPassword \
  -p 8161:8161 \
  -p 61616:61616 \
   apache/activemq-classic:6.1.0
```