### PR TITLE
Upgrade to Camel 4.6 part 2

### DIFF
--- a/components/camel-aws/camel-aws2-ddb/pom.xml
+++ b/components/camel-aws/camel-aws2-ddb/pom.xml
@@ -37,8 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;version=${camel.version};resolution:=optional,
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -37,8 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;version=${camel.version};resolution:=optional,
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/components/camel-azure/camel-azure-cosmosdb/pom.xml
+++ b/components/camel-azure/camel-azure-cosmosdb/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-azure/camel-azure-eventhubs/pom.xml
+++ b/components/camel-azure/camel-azure-eventhubs/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-azure/camel-azure-files/pom.xml
+++ b/components/camel-azure/camel-azure-files/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-azure/camel-azure-servicebus/pom.xml
+++ b/components/camel-azure/camel-azure-servicebus/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-azure/camel-azure-storage-blob/pom.xml
+++ b/components/camel-azure/camel-azure-storage-blob/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-azure/camel-azure-storage-datalake/pom.xml
+++ b/components/camel-azure/camel-azure-storage-datalake/pom.xml
@@ -37,8 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;version=${camel.version};resolution:=optional,
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/components/camel-azure/camel-azure-storage-queue/pom.xml
+++ b/components/camel-azure/camel-azure-storage-queue/pom.xml
@@ -36,6 +36,10 @@
         <camel.osgi.export>
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
+        <camel.osgi.camel.import>
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
+        </camel.osgi.camel.import>
         <camel.osgi.import>
             *
         </camel.osgi.import>

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -38,7 +38,7 @@
         </camel.osgi.export>
         <camel.osgi.camel.import>
             org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            *
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -37,8 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;version=${camel.version};resolution:=optional,
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/components/camel-spring/pom.xml
+++ b/components/camel-spring/pom.xml
@@ -37,8 +37,8 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.camel.import>
-            org.apache.camel.component.cron*;version=${camel.version};resolution:=optional,
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel.component.cron*;${camel.osgi.import.camel.version};resolution:=optional,
+            org.apache.camel*;${camel.osgi.import.camel.version},
         </camel.osgi.camel.import>
         <camel.osgi.import>
             *

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -172,21 +172,21 @@
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/regions/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/utils/${aws-java-sdk2-version}</bundle>
     </feature>
-    <feature name="azure" version="1.46.0" start-level="50">
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/1.46.0</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-identity/1.11.2</bundle>
+    <feature name="azure" version="1.48.0" start-level="50">
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/1.48.0</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-identity/1.12.0</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
-        <bundle dependency='true'>mvn:io.projectreactor/reactor-core/3.4.34</bundle>
+        <bundle dependency='true'>mvn:io.projectreactor/reactor-core/3.4.36</bundle>
     </feature>
-    <feature name="azure-storage" version="1.46.0" start-level="50">
-        <feature version='[1.46,1.47)'>azure</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-common/12.24.1</bundle>
+    <feature name="azure-storage" version="1.48.0" start-level="50">
+        <feature version='[1.48,2)'>azure</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-common/12.24.4</bundle>
     </feature>
-    <feature name="azure-eventhubs" version="1.46.0" start-level="50">
-        <feature version='[1.46,1.47)'>azure-storage</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/2.9.1</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs/5.18.1</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs-checkpointstore-blob/1.19.1</bundle>
+    <feature name="azure-eventhubs" version="1.48.0" start-level="50">
+        <feature version='[1.48,2)'>azure-storage</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/2.9.3</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs/5.18.3</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs-checkpointstore-blob/1.19.3</bundle>
     </feature>
     <feature name="guava" version="${guava-version}">
         <bundle dependency='true'>mvn:com.google.guava/guava/${guava-version}</bundle>
@@ -512,63 +512,62 @@
         <bundle>mvn:org.apache.camel.karaf/camel-aws-xray/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-cosmosdb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='[2.16,2.17)'>jackson</feature>
-        <feature version='[1.46,1.47)'>azure</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-cosmos/4.56.0</bundle>
+        <feature version='[1.48,2)'>azure</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-cosmos/4.58.0</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-cosmosdb/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-eventhubs' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='[1.46,1.47)'>azure-eventhubs</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.2</bundle>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='[1.48,2)'>azure-eventhubs</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-eventhubs/${project.version}</bundle>
     </feature>  
     <feature name='camel-azure-files' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-ftp</feature>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='[1.46,1.47)'>azure-storage</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-share/12.21.2</bundle>
+        <feature version='[1.48,2)'>azure-storage</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-share/12.21.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-files/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-key-vault' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='[2.16,2.17)'>jackson</feature>
-        <feature version='[1.46,1.47)'>azure-eventhubs</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-security-keyvault-secrets/4.8.0</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.2</bundle>
+        <feature version='[1.48,2)'>azure-eventhubs</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-security-keyvault-secrets/4.8.2</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-key-vault/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-schema-registry' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.46,1.47)'>azure</feature>
+        <feature version='[1.48,2)'>azure</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-schema-registry/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-servicebus' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='[1.46,1.47)'>azure</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/2.9.1</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-servicebus/7.15.1</bundle>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='[1.48,2)'>azure</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/2.9.3</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-servicebus/7.16.0</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-servicebus/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-blob' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='[1.46,1.47)'>azure-storage</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.2</bundle>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='[1.48,2)'>azure-storage</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/12.25.4</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob-changefeed/${azure-storage-blob-changefeed-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-blob/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-datalake' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.46,1.47)'>azure-storage</feature>
+        <feature version='[1.48,2)'>azure-storage</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-datalake/12.18.1</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-datalake/12.18.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-datalake/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-queue' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='[1.46,1.47)'>azure-storage</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-queue/12.20.1</bundle>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='[1.48,2)'>azure-storage</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-queue/12.20.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-queue/${project.version}</bundle>
     </feature>
     <feature name='camel-base64' version='${project.version}' start-level='50'>


### PR DESCRIPTION
* Upgrade to azure 1.48
* Make `cloudevents` optional for all Azure features like in the upstream project
* Fix import version for camel packages