### PR TITLE
Add missing bundles and features for camel-aws2-ses to awssdk

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -158,13 +158,29 @@
     </feature>
 
     <feature name="awssdk" version="${aws-java-sdk2-version}" start-level="50">
+        <feature prerequisite="true">spifly</feature>
+        <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/auth/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-core/${aws-java-sdk2-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sdk-core/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sdk-core/${aws-java-sdk2-version}$${spi-consumer}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-client-spi/${aws-java-sdk2-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}$${spi-provider}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/regions/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/utils/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/identity-spi/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/profiles/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/endpoints-spi/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth-spi/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth-aws/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/metrics-spi/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-query-protocol/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/protocol-core/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/checksums/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/checksums-spi/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/json-utils/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/third-party-jackson-core/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
     </feature>
     <feature name="azure" version="1.48.0" start-level="50">
         <bundle dependency='true'>wrap:mvn:com.azure/azure-core/1.48.0</bundle>

--- a/tests/features/camel-aws2-ses/pom.xml
+++ b/tests/features/camel-aws2-ses/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-aws2-ses-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: AWS2 SES</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-aws2-ses/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-aws2-ses/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+    <!-- Allow the use of system properties -->
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]"/>
+
+
+    <bean id="ses2Configuration" class="org.apache.camel.component.aws2.ses.Ses2Configuration">
+        <property name="accessKey" value="$[localstack.ses.accessKey]"/>
+        <property name="secretKey" value="$[localstack.ses.secretKey]"/>
+        <property name="region" value="$[localstack.ses.region]"/>
+        <property name="overrideEndpoint" value="true"/>
+        <property name="uriEndpointOverride" value="http://$[localstack.ses.host]:$[localstack.ses.port]"/>
+    </bean>
+
+    <bean id="aws2-ses" class="org.apache.camel.component.aws2.ses.Ses2Component">
+        <property name="configuration" ref="ses2Configuration"/>
+    </bean>
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
+        <route id="sendEmailRoute">
+            <from uri="direct:camel-aws2-ses-test"/>
+            <setHeader name="CamelAwsSesFrom">
+                <constant>sender@example.com</constant>
+            </setHeader>
+            <setHeader name="CamelAwsSesTo">
+                <constant>recipient@example.com</constant>
+            </setHeader>
+            <setHeader name="CamelAwsSesSubject">
+                <constant>Test Email</constant>
+            </setHeader>
+            <setBody>
+                <constant>Hello, this is a test email sent from Apache Camel using AWS SES!</constant>
+            </setBody>
+            <to uri="aws2-ses://default"/>
+            <log message="Sent email: ${body}"/>
+            <setBody>
+                <constant>OK</constant>
+            </setBody>
+            <to uri="mock:camel-aws2-ses-test"/>
+        </route>
+    </camelContext>
+</blueprint>

--- a/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
+++ b/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
@@ -50,8 +50,8 @@ public class CamelAws2SesITest extends AbstractCamelSingleFeatureResultMockBased
         public static GenericContainerResource<LocalStackContainer> createAws2SesContainer() {
 
             final LocalStackContainer localStackContainer =
-                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest")).withServices(
-                            LocalStackContainer.Service.SES);
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+                        .withServices(LocalStackContainer.Service.SES);
             return new GenericContainerResource<>(localStackContainer, resource -> {
                 try {
                     localStackContainer.execInContainer("aws", "configure", "set", "aws_access_key_id", ACCESS_KEY, "--profile",

--- a/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
+++ b/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@CamelKarafTestHint(externalResourceProvider = CamelAws2SesITest.ExternalResourceProviders.class, isBlueprintTest = true)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelAws2SesITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final int LOCALSTACK_ORIGINAL_PORT = 4566;
+        private static final String ACCESS_KEY = "test";
+        private static final String SECRET_KEY = "test";
+        private static final String REGION = "us-east-1";
+
+        public static GenericContainerResource<LocalStackContainer> createAws2SesContainer() {
+
+            final LocalStackContainer localStackContainer =
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest")).withServices(
+                            LocalStackContainer.Service.SES);
+            return new GenericContainerResource<>(localStackContainer, resource -> {
+                try {
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_access_key_id", ACCESS_KEY, "--profile",
+                            "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_secret_access_key", SECRET_KEY,
+                            "--profile", "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "region", REGION, "--profile", "localstack");
+                    localStackContainer.execInContainer("aws",
+                            "--endpoint-url=http://" + localStackContainer.getHost() + ":" + LOCALSTACK_ORIGINAL_PORT, "ses",
+                            "verify-email-identity", "--email-address", "sender@example.com", "--region", REGION, "--profile",
+                            "localstack");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                resource.setProperty("localstack.ses.host", localStackContainer.getHost());
+                resource.setProperty("localstack.ses.port",
+                        Integer.toString(localStackContainer.getMappedPort(LOCALSTACK_ORIGINAL_PORT)));
+                resource.setProperty("localstack.ses.accessKey", ACCESS_KEY);
+                resource.setProperty("localstack.ses.secretKey", SECRET_KEY);
+                resource.setProperty("localstack.ses.region", REGION);
+            });
+        }
+    }
+}

--- a/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
+++ b/tests/features/camel-aws2-ses/src/test/java/org/apache/karaf/camel/itest/CamelAws2SesITest.java
@@ -50,7 +50,7 @@ public class CamelAws2SesITest extends AbstractCamelSingleFeatureResultMockBased
         public static GenericContainerResource<LocalStackContainer> createAws2SesContainer() {
 
             final LocalStackContainer localStackContainer =
-                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4.0"))
                         .withServices(LocalStackContainer.Service.SES);
             return new GenericContainerResource<>(localStackContainer, resource -> {
                 try {

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -38,6 +38,7 @@
 
     <modules>
         <module>camel-amqp</module>
+        <module>camel-aws2-ses</module>
         <module>camel-core</module>
         <module>camel-elasticsearch</module>
         <module>camel-jetty</module>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/308

Motivation
During testing using an OSGI blueprint, it turned out that the camel-aws2-ses is missing bundles to successfully execute the route.

Modifications:
Add the missing bundles with appropriate SPI provide/consume statements

To run localstack (AWS emulator):
`docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack`
In the emulator run
`aws configure --profile localstack`
and enter in the prompt:
```
test
test
us-east-1
json
```
to get
```
AWS Access Key ID [None]: test
AWS Secret Access Key [None]: test
Default region name [None]: us-east-1
Default output format [None]: json
```
And verify the sender's email in localstack console
`aws --endpoint-url=http://localhost:4566 ses verify-email-identity --email-address sender@example.com --region us-east-1 --profile localstack`

Deploy the following blueprint (the endpoint is producer-only, so only one route):
```
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
           xsi:schemaLocation="
             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">

    <bean id="ses2Configuration" class="org.apache.camel.component.aws2.ses.Ses2Configuration">
        <property name="accessKey" value="test"/>
        <property name="secretKey" value="test"/>
        <property name="region" value="us-east-1"/>
        <property name="overrideEndpoint" value="true"/>
        <property name="uriEndpointOverride" value="http://localhost:4566"/>
    </bean>

    <bean id="aws2-ses" class="org.apache.camel.component.aws2.ses.Ses2Component">
        <property name="configuration" ref="ses2Configuration"/>
    </bean>
    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
        <route id="sendEmailRoute">
            <from uri="timer:sendEmailTimer?period=5000"/> 
              <setHeader name="CamelAwsSesFrom">
                <constant>sender@example.com</constant>
            </setHeader>
            <setHeader name="CamelAwsSesTo">
                <constant>recipient@example.com</constant>
            </setHeader>
            <setHeader name="CamelAwsSesSubject">
                <constant>Test Email</constant>
            </setHeader>
            <setBody>
                <constant>Hello, this is a test email sent from Apache Camel using AWS SES!</constant>
            </setBody>
            <to uri="aws2-ses://default"/>
            <log message="Sent email: ${body}"/>
        </route>
    </camelContext>
</blueprint>
```
Observe the following output:
```
01:32:04.093 INFO [Camel (camel-4) thread #7 - timer://sendEmailTimer] Sent email: Hello, this is a test email sent from Apache Camel using AWS SES!
01:32:09.090 INFO [Camel (camel-4) thread #7 - timer://sendEmailTimer] Sent email: Hello, this is a test email sent from Apache Camel using AWS SES!
01:32:14.136 INFO [Camel (camel-4) thread #7 - timer://sendEmailTimer] Sent email: Hello, this is a test email sent from Apache Camel using AWS SES!
```
And the following output in localstack:
```
2024-05-30T22:32:34.111  INFO --- [et.reactor-0] localstack.request.aws     : AWS ses.SendEmail => 200
2024-05-30T22:32:39.103  INFO --- [et.reactor-1] localstack.request.aws     : AWS ses.SendEmail => 200
2024-05-30T22:32:44.117  INFO --- [et.reactor-1] localstack.request.aws     : AWS ses.SendEmail => 200
```

The features and bundles were added to awssdk feature as these dependencies are common with other aws features, e.g. camel-aws2-sns and camel-aws2-sqs