### PR TITLE
Fix camel-mail and add integration tests

### DIFF
--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -38,7 +38,6 @@
         </camel.osgi.export>
         <camel.osgi.import>
             jakarta.mail*;version="[2,3)",
-            org.eclipse.angus*;resolution:=optional,
             *
         </camel.osgi.import>
     </properties>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1611,8 +1611,10 @@
         <bundle>mvn:org.apache.camel.karaf/camel-lzf/${project.version}</bundle>
     </feature>
     <feature name='camel-mail' version='${project.version}' start-level='50'>
+        <feature prerequisite="true">spifly</feature>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <bundle dependency='true'>mvn:com.sun.mail/jakarta.mail/2.0.1</bundle>
+        <bundle dependency="true">mvn:jakarta.mail/jakarta.mail-api/2.1.3</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.angus/angus-mail/${angus-mail-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mail/${project.version}</bundle>
     </feature>

--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/GenericContainerResource.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/GenericContainerResource.java
@@ -67,7 +67,6 @@ public class GenericContainerResource<T extends GenericContainer<T>> implements 
 
     @Override
     public void after() {
-        container.stop();
         for (ExternalResource dependency : dependencies) {
             try {
                 dependency.after();
@@ -75,6 +74,7 @@ public class GenericContainerResource<T extends GenericContainer<T>> implements 
                 LOG.warn("Error cleaning dependency: {}", dependency.getClass().getName(), e);
             }
         }
+        container.stop();
         LOG.info("Container {} stopped", container.getDockerImageName());
     }
 

--- a/tests/features/camel-mail/pom.xml
+++ b/tests/features/camel-mail/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-mail-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Mail</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/features/camel-mail/src/main/java/org/apache/karaf/camel/test/CamelMailRouteSupplier.java
+++ b/tests/features/camel-mail/src/main/java/org/apache/karaf/camel/test/CamelMailRouteSupplier.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import java.util.function.Function;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+
+@Component(
+        name = "karaf-camel-mail-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelMailRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder ->
+                builder.from(
+                        "pop3://camel@localhost:%s?password=foo&initialDelay=100&delay=500"
+                                .formatted(System.getProperty("pop3.port"))).log("received message ${body} from:${header.from} to:${header.to} subj: ${header.subject}");
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute.log("calling mail endpoint")
+                .setBody(builder.constant("OK"))
+                .setHeader("Subject", builder.constant("Test"))
+                .setHeader("From", builder.constant("origin@localhost"))
+                .setHeader("To", builder.constant("camel@localhost"))
+                .to("smtp://camel@localhost:%s?password=foo".formatted(System.getProperty("smtp.port")));
+    }
+}
+

--- a/tests/features/camel-mail/src/main/java/org/apache/karaf/camel/test/CamelMailRouteSupplier.java
+++ b/tests/features/camel-mail/src/main/java/org/apache/karaf/camel/test/CamelMailRouteSupplier.java
@@ -35,9 +35,9 @@ public class CamelMailRouteSupplier extends AbstractCamelSingleFeatureResultMock
     @Override
     protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
         return builder ->
-                builder.from(
-                        "pop3://camel@localhost:%s?password=foo&initialDelay=100&delay=500"
-                                .formatted(System.getProperty("pop3.port"))).log("received message ${body} from:${header.from} to:${header.to} subj: ${header.subject}");
+                builder.fromF(
+                        "pop3://camel@localhost:%s?password=foo&initialDelay=100&delay=500",System.getProperty("pop3.port"))
+                        .log("received message ${body} from:${header.from} to:${header.to} subj: ${header.subject}");
     }
 
     @Override
@@ -47,7 +47,7 @@ public class CamelMailRouteSupplier extends AbstractCamelSingleFeatureResultMock
                 .setHeader("Subject", builder.constant("Test"))
                 .setHeader("From", builder.constant("origin@localhost"))
                 .setHeader("To", builder.constant("camel@localhost"))
-                .to("smtp://camel@localhost:%s?password=foo".formatted(System.getProperty("smtp.port")));
+                .toF("smtp://camel@localhost:%s?password=foo",System.getProperty("smtp.port"));
     }
 }
 

--- a/tests/features/camel-mail/src/test/java/org/apache/karaf/camel/itest/CamelMailITest.java
+++ b/tests/features/camel-mail/src/test/java/org/apache/karaf/camel/itest/CamelMailITest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+
+@CamelKarafTestHint(externalResourceProvider = CamelMailITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelMailITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK\r\n");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static class MailContainer extends FixedHostPortGenericContainer<MailContainer> {
+        public MailContainer(String dockerImage) {
+            super(dockerImage);
+        }
+    }
+
+    public static final class ExternalResourceProviders {
+        public static GenericContainerResource<MailContainer> createGreenMailContainer() {
+            int smtpport = Utils.getNextAvailablePort();
+            int pop3port = Utils.getNextAvailablePort(port -> port != smtpport);
+            final MailContainer greenMailContainer =
+                    new MailContainer("greenmail/standalone:2.0.1").withFixedExposedPort(smtpport, 3025)
+                            .withFixedExposedPort(pop3port, 3110)
+                            .withEnv("GREENMAIL_OPTS", "-Dgreenmail.users=camel:foo@localhost -Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled");
+
+            return new GenericContainerResource<>(greenMailContainer, resource -> {
+                resource.setProperty("smtp.port", "%s".formatted(smtpport));
+                resource.setProperty("pop3.port", "%s".formatted(pop3port));
+            });
+        }
+    }
+}

--- a/tests/features/camel-mail/src/test/java/org/apache/karaf/camel/itest/CamelMailITest.java
+++ b/tests/features/camel-mail/src/test/java/org/apache/karaf/camel/itest/CamelMailITest.java
@@ -52,8 +52,8 @@ public class CamelMailITest extends AbstractCamelSingleFeatureResultMockBasedRou
                             .withEnv("GREENMAIL_OPTS", "-Dgreenmail.users=camel:foo@localhost -Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled");
 
             return new GenericContainerResource<>(greenMailContainer, resource -> {
-                resource.setProperty("smtp.port", "%s".formatted(smtpport));
-                resource.setProperty("pop3.port", "%s".formatted(pop3port));
+                resource.setProperty("smtp.port", Integer.toString(smtpport));
+                resource.setProperty("pop3.port", Integer.toString(pop3port));
             });
         }
     }

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -41,6 +41,7 @@
         <module>camel-core</module>
         <module>camel-elasticsearch</module>
         <module>camel-jetty</module>
+        <module>camel-mail</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Ref #315
Fix of camel-mail feature which requires angus as mail protocol implementation
Add integration tests using greenmail (same as in camel but as a container)