### PR TITLE
Added missing bundles for camel-aws2-sqs and integration test

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -469,6 +469,7 @@
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sqs/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-sqs/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-step-functions' version='${project.version}' start-level='50'>

--- a/tests/features/camel-aws2-sqs/pom.xml
+++ b/tests/features/camel-aws2-sqs/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-aws2-sqs-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: AWS2 SQS</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-aws2-sqs/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-aws2-sqs/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+    <!-- Allow the use of system properties -->
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]"/>
+
+    <bean id="sqs2Configuration" class="org.apache.camel.component.aws2.sqs.Sqs2Configuration">
+        <property name="accessKey" value="$[localstack.sqs.accessKey]"/>
+        <property name="secretKey" value="$[localstack.sqs.secretKey]"/>
+        <property name="region" value="$[localstack.sqs.region]"/>
+        <property name="overrideEndpoint" value="true"/>
+        <property name="uriEndpointOverride" value="http://$[localstack.sqs.host]:$[localstack.sqs.port]"/>
+    </bean>
+
+    <bean id="aws2-sqs" class="org.apache.camel.component.aws2.sqs.Sqs2Component">
+        <property name="configuration" ref="sqs2Configuration"/>
+    </bean>
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
+        <route id="sendToSqsRoute">
+            <from uri="direct:camel-aws2-sqs-test"/>
+            <setBody>
+                <constant>Hello, this is a test message from AWS SQS!</constant>
+            </setBody>
+            <to uri="aws2-sqs://my-queue"/>
+            <log message="Sent message: ${body}"/>
+        </route>
+        <route id="receiveFromSqsRoute">
+            <from uri="aws2-sqs://my-queue"/>
+            <log message="Received message: ${body}"/>
+            <setBody>
+                <constant>OK</constant>
+            </setBody>
+            <to uri="mock:camel-aws2-sqs-test"/>
+        </route>
+    </camelContext>
+</blueprint>

--- a/tests/features/camel-aws2-sqs/src/test/java/org/apache/karaf/camel/itest/CamelAws2SqsITest.java
+++ b/tests/features/camel-aws2-sqs/src/test/java/org/apache/karaf/camel/itest/CamelAws2SqsITest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@CamelKarafTestHint(externalResourceProvider = CamelAws2SqsITest.ExternalResourceProviders.class, isBlueprintTest = true)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelAws2SqsITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final int LOCALSTACK_ORIGINAL_PORT = 4566;
+        private static final String ACCESS_KEY = "test";
+        private static final String SECRET_KEY = "test";
+        private static final String REGION = "us-east-1";
+
+        public static GenericContainerResource<LocalStackContainer> createAws2SqsContainer() {
+
+            final LocalStackContainer localStackContainer =
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4.0"))
+                            .withServices(LocalStackContainer.Service.SQS);
+
+            return new GenericContainerResource<>(localStackContainer, resource -> {
+                try {
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_access_key_id", ACCESS_KEY, "--profile",
+                            "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_secret_access_key", SECRET_KEY,
+                            "--profile", "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "region", REGION, "--profile", "localstack");
+                    localStackContainer.execInContainer("aws",
+                            "--endpoint-url=http://" + localStackContainer.getHost() + ":" + LOCALSTACK_ORIGINAL_PORT, "sqs",
+                            "create-queue", "--queue-name", "my-queue", "--region", REGION, "--profile", "localstack");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                resource.setProperty("localstack.sqs.host", localStackContainer.getHost());
+                resource.setProperty("localstack.sqs.port",
+                        Integer.toString(localStackContainer.getMappedPort(LOCALSTACK_ORIGINAL_PORT)));
+                resource.setProperty("localstack.sqs.accessKey", ACCESS_KEY);
+                resource.setProperty("localstack.sqs.secretKey", SECRET_KEY);
+                resource.setProperty("localstack.sqs.region", REGION);
+            });
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -39,6 +39,7 @@
     <modules>
         <module>camel-amqp</module>
         <module>camel-aws2-ses</module>
+        <module>camel-aws2-sqs</module>
         <module>camel-core</module>
         <module>camel-elasticsearch</module>
         <module>camel-jetty</module>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/320

Motivation

- During testing using an OSGI blueprint, it turned out that the camel-aws2-sqs is missing bundles to successfully execute the route.

Modifications:

- Add the missing bundles
- Add an integration test for camel-aws2-sqs

To run localstack (AWS emulator):
`docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack`
In the emulator run
`aws configure --profile localstack`
and enter in the prompt:

```
test
test
us-east-1
json
```
to get

```
AWS Access Key ID [None]: test
AWS Secret Access Key [None]: test
Default region name [None]: us-east-1
Default output format [None]: json
```
Create an sqs queue in the localstack
`aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name my-queue`

Deploy the following blueprint

```
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
           xsi:schemaLocation="
             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">

    <bean id="sqs2Configuration" class="org.apache.camel.component.aws2.sqs.Sqs2Configuration">
        <property name="accessKey" value="test"/>
        <property name="secretKey" value="test"/>
        <property name="region" value="us-east-1"/>
        <property name="overrideEndpoint" value="true"/>
        <property name="uriEndpointOverride" value="http://localhost:4566"/>
    </bean>

    <bean id="aws2-sqs" class="org.apache.camel.component.aws2.sqs.Sqs2Component">
        <property name="configuration" ref="sqs2Configuration"/>
    </bean>
    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
        <route id="sendSqsMessageRoute">
            <from uri="timer:sendEmailTimer?period=5000"/> 
            <setBody>
                <constant>Hello, this is a test message from AWS sqs!</constant>
            </setBody>
            <to uri="aws2-sqs://my-queue"/>
            <log message="Sent message: ${body}"/>
        </route>
        <route id="receiveFromSqsRoute">
            <from uri="aws2-sqs://my-queue"/>
            <log message="Received message: ${body}"/>
        </route>
    </camelContext>
</blueprint>

```

Observe the following output:
```
00:35:15.569 INFO [Camel (camel-1) thread #2 - timer://sendEmailTimer] Sent message: Hello, this is a test message from AWS sqs!
00:35:15.898 INFO [Camel (camel-1) thread #1 - aws2-sqs://my-queue] Received message: Hello, this is a test message from AWS sqs!
00:35:20.571 INFO [Camel (camel-1) thread #2 - timer://sendEmailTimer] Sent message: Hello, this is a test message from AWS sqs!
00:35:21.062 INFO [Camel (camel-1) thread #1 - aws2-sqs://my-queue] Received message: Hello, this is a test message from AWS sqs!
00:35:25.586 INFO [Camel (camel-1) thread #2 - timer://sendEmailTimer] Sent message: Hello, this is a test message from AWS sqs!
00:35:25.730 INFO [Camel (camel-1) thread #1 - aws2-sqs://my-queue] Received message: Hello, this is a test message from AWS sqs!
```

Also, an integration test was added to test the feature (artifact camel-aws2-sqs-test) - run `mvn clean verify` in the folder to run the test