### PR TITLE
Add camel netty http test with rest

### DIFF
--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
@@ -70,7 +70,14 @@ public class CamelSuppliedRouteLauncher extends AbstractCamelRouteLauncher imple
 
     @SuppressWarnings("SuspiciousMethodCalls")
     private boolean ignore(ServiceReference<?> serviceReference) {
-        return !suppliers.isEmpty() && !suppliers.contains(serviceReference.getProperty("component.name"));
+        boolean result = false;
+        if (!suppliers.isEmpty()) {
+            Object componentName = serviceReference.getProperty("component.name");
+            if (componentName != null && !suppliers.contains(serviceReference.getProperty("component.name"))) {
+                result = true;
+            }
+        }
+        return result;
     }
 
     @Override

--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
@@ -73,9 +73,7 @@ public class CamelSuppliedRouteLauncher extends AbstractCamelRouteLauncher imple
         boolean result = false;
         if (!suppliers.isEmpty()) {
             Object componentName = serviceReference.getProperty("component.name");
-            if (componentName != null && !suppliers.contains(serviceReference.getProperty("component.name"))) {
-                result = true;
-            }
+            result = componentName != null && !suppliers.contains(componentName);
         }
         return result;
     }

--- a/tests/features/camel-netty-http/src/main/java/org/apache/karaf/camel/test/CamelRestNettyHttpRouteSupplier.java
+++ b/tests/features/camel-netty-http/src/main/java/org/apache/karaf/camel/test/CamelRestNettyHttpRouteSupplier.java
@@ -1,0 +1,56 @@
+package org.apache.karaf.camel.test;
+
+import java.util.function.Function;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.spi.RestConfiguration;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+        name = "karaf-camel-rest-netty-http-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelRestNettyHttpRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String REST_PORT = "rest.port";
+
+    @Override
+    protected String getResultMockName() {
+        return "camel-netty-http-test";
+    }
+
+    @Override
+    public String getTestComponentName() {
+        return "camel-netty-http-test";
+    }
+
+    @Override
+    public void configure(CamelContext camelContext) {
+        RestConfiguration config = new RestConfiguration();
+        config.setComponent("netty-http");
+        config.setHost("127.0.0.1");
+        config.setPort(Integer.parseInt(System.getProperty(REST_PORT)));
+        camelContext.setRestConfiguration(config);
+    }
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder ->
+                builder.fromF("rest:get:testRestNetty")
+                        .log("receiving rest http request")
+                        .setBody(builder.constant("OK"));
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute.log("calling http endpoint")
+                .setBody(builder.constant("OK"))
+                .log("sending rest http request")
+                .toF("rest:get:testRestNetty?host=127.0.0.1:%s", System.getProperty(REST_PORT));
+    }
+}

--- a/tests/features/camel-netty-http/src/test/java/org/apache/karaf/camel/itest/CamelRestNettyHttpITest.java
+++ b/tests/features/camel-netty-http/src/test/java/org/apache/karaf/camel/itest/CamelRestNettyHttpITest.java
@@ -14,21 +14,34 @@
 package org.apache.karaf.camel.itest;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.karaf.camel.itests.*;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.AvailablePortProvider;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
 @CamelKarafTestHint(
-        externalResourceProvider = CamelNettyHttpITest.ExternalResourceProviders.class,
-        camelRouteSuppliers = "karaf-camel-netty-http-test")
+        externalResourceProvider = CamelRestNettyHttpITest.ExternalResourceProviders.class,
+        camelRouteSuppliers = "karaf-camel-rest-netty-http-test")
 @RunWith(PaxExamWithExternalResource.class)
 @ExamReactorStrategy(PerClass.class)
-public class CamelNettyHttpITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+public class CamelRestNettyHttpITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
 
+    @Override
+    public String getTestComponentName() {
+        return "camel-netty-http-test";
+    }
+
+    @Override
+    public String getCamelFeatureName() {
+        return "camel-netty-http";
+    }
 
     @Override
     public void configureMock(MockEndpoint mock) {
@@ -42,7 +55,7 @@ public class CamelNettyHttpITest extends AbstractCamelSingleFeatureResultMockBas
 
     public static final class ExternalResourceProviders {
         public static AvailablePortProvider createAvailablePortProvider() {
-            return new AvailablePortProvider(List.of("http.port"));
+            return new AvailablePortProvider(List.of("rest.port"));
         }
 
     }


### PR DESCRIPTION
Fixes #322

- camel netty http test with rest
- Fix a NullPointer problem in CamelSuppliedRouteLauncher  when the property component.name is null 