### PR TITLE
Added camel-spring-rabbitmq integration test

### DIFF
--- a/tests/features/camel-spring-rabbitmq/pom.xml
+++ b/tests/features/camel-spring-rabbitmq/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>camel-spring-rabbitmq-test</artifactId>
-    <name>Apache Camel :: Karaf :: Tests :: Features :: RabbitMQ</name>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Spring RabbitMQ</name>
 
     <dependencies>
         <dependency>

--- a/tests/features/camel-spring-rabbitmq/pom.xml
+++ b/tests/features/camel-spring-rabbitmq/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-spring-rabbitmq-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: RabbitMQ</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-spring-rabbitmq/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-spring-rabbitmq/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -27,6 +27,7 @@
 
     <bean id="rabbitConnectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
         <argument value="$[spring.rabbitmq.host]"/>
+        <argument value="$[spring.rabbitmq.port]"/>
     </bean>
 
     <bean id="spring-rabbitmq" class="org.apache.camel.component.springrabbit.SpringRabbitMQComponent">

--- a/tests/features/camel-spring-rabbitmq/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-spring-rabbitmq/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+    <!-- Allow the use of system properties -->
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]"/>
+
+    <bean id="rabbitConnectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
+        <argument value="$[spring.rabbitmq.host]"/>
+    </bean>
+
+    <bean id="spring-rabbitmq" class="org.apache.camel.component.springrabbit.SpringRabbitMQComponent">
+        <property name="connectionFactory" ref="rabbitConnectionFactory"/>
+    </bean>
+
+    <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/blueprint">
+
+        <route id="rabbitRouteSend">
+            <from uri="direct:camel-spring-rabbitmq-test"/>
+            <setHeader name="theHeader">
+                <constant>This is header</constant>
+            </setHeader>
+            <setBody>
+                <constant>Hello Camel</constant>
+            </setBody>
+            <to uri="spring-rabbitmq:exchangeName?routingKey=routingKey"/>
+            <log message="Message sent to RabbitMQ: ${body} headers ${header.theHeader}"/>
+        </route>
+
+        <route id="rabbitRouteReceive">
+            <from uri="spring-rabbitmq:exchangeName?routingKey=routingKey"/>
+            <log message="Message received from RabbitMQ: ${body} headers ${header.theHeader}"/>
+            <setBody>
+                <constant>OK</constant>
+            </setBody>
+            <to uri="mock:camel-spring-rabbitmq-test"/>
+        </route>
+    </camelContext>
+</blueprint>

--- a/tests/features/camel-spring-rabbitmq/src/test/java/org/apache/karaf/camel/itest/CamelSpringRabbitmqITest.java
+++ b/tests/features/camel-spring-rabbitmq/src/test/java/org/apache/karaf/camel/itest/CamelSpringRabbitmqITest.java
@@ -49,6 +49,7 @@ public class CamelSpringRabbitmqITest extends AbstractCamelSingleFeatureResultMo
 
             return new GenericContainerResource<>(rabbitMQContainer, resource -> {
                 resource.setProperty("spring.rabbitmq.host", rabbitMQContainer.getHost());
+                resource.setProperty("spring.rabbitmq.port", Integer.toString(rabbitMQContainer.getAmqpPort()));
             });
         }
     }

--- a/tests/features/camel-spring-rabbitmq/src/test/java/org/apache/karaf/camel/itest/CamelSpringRabbitmqITest.java
+++ b/tests/features/camel-spring-rabbitmq/src/test/java/org/apache/karaf/camel/itest/CamelSpringRabbitmqITest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@CamelKarafTestHint(externalResourceProvider = CamelSpringRabbitmqITest.ExternalResourceProviders.class, isBlueprintTest = true)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelSpringRabbitmqITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        public static GenericContainerResource<RabbitMQContainer> createSpringRabbitMqContainer() {
+
+            final RabbitMQContainer rabbitMQContainer =
+                    new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.13.1"));
+
+            return new GenericContainerResource<>(rabbitMQContainer, resource -> {
+                resource.setProperty("spring.rabbitmq.host", rabbitMQContainer.getHost());
+            });
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -47,6 +47,7 @@
         <module>camel-jetty</module>
         <module>camel-netty-http</module>
         <module>camel-mail</module>
+        <module>camel-spring-rabbitmq</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/332
Motivation

During testing using an OSGI blueprint, it turned out that the camel-spring-rabbitmq no missing bundles to successfully execute the route, but requires an integration test
Modifications:

Add an integration test for camel-spring-rabbitmq

To test manually install 

```
repo-add mvn:org.apache.camel.karaf/apache-camel/4.5.0-SNAPSHOT/xml/features
feature:install
camel-blueprint camel-spring-rabbitmq 

```
Launch the docker container

`docker run -d --name test_rabbitmq -p 5672:5672 rabbitmq:3.13.1 `
and copy file spring-rabbitmq.xml (or create one with the following content)

```
<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
           xsi:schemaLocation="
             http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">

    <bean id="rabbitConnectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
        <argument value="localhost"/>
    </bean>

    <bean id="spring-rabbitmq" class="org.apache.camel.component.springrabbit.SpringRabbitMQComponent">
        <property name="connectionFactory" ref="rabbitConnectionFactory"/>
    </bean>

    <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/blueprint">
        
        <route id="rabbitRouteSend">
            <from uri="timer://testTimer?fixedRate=true&amp;period=5000"/>
            <setHeader name="theHeader">
                <constant>This is header</constant>
            </setHeader>
            <setBody>
                <constant>Hello Camel</constant>
            </setBody>
            <to uri="spring-rabbitmq:exchangeName?routingKey=routingKey"/>
            <log message="Message sent to RabbitMQ: ${body} headers ${header.theHeader}"/>
        </route>

        <route id="rabbitRouteReceive">
            <from uri="spring-rabbitmq:exchangeName?routingKey=routingKey"/>
            <log message="Message received from RabbitMQ: ${body} headers ${header.theHeader}"/>
            <choice>
                <when>
                    <simple>${header.theHeader} != 'This is header'</simple>
                    <log message="KO - not expected ${header.theHeader}"/>
                    <throwException exceptionType="java.lang.Exception" message="An unexpected header returned"/>
                </when>
                <otherwise>
                    <log message="OK - expected ${header.theHeader}"/>
                </otherwise>
            </choice>
            <choice>
                <when>
                    <simple>${body} != 'Hello Camel'</simple>
                    <log message="KO - not expected ${body}"/>
                    <throwException exceptionType="java.lang.Exception" message="An unexpected body returned"/>
                </when>
                <otherwise>
                    <log message="OK - expected ${body}"/>
                </otherwise>
            </choice>
        </route>
    </camelContext>
</blueprint>

```

Observe the following output:

```
10:42:34.772 INFO [Blueprint Event Dispatcher: 1] Apache Camel 4.5.0 (camelContext) started in 124ms (build:0ms init:0ms start:124ms)
10:42:34.773 INFO [fileinstall-/Users/ylopushen/Talend/demo/apache-karaf-4.4.6/deploy] Started bundle: blueprint:file:/Users/ylopushen/Talend/demo/apache-karaf-4.4.6/deploy/spring-rabbitmq.xml
10:42:34.775 INFO [not.a.Spring.bean-1] SimpleConsumer [queue=spring.gen-8hoQR7V8RJK2fdnX0kQnww, index=0, consumerTag=amq.ctag-UiQ2aOk9Oa5MccKMk_y0pA identity=762797a] started
10:42:35.821 INFO [Camel (camel-1) thread #1 - timer://testTimer] Message sent to RabbitMQ: Hello Camel headers This is header
10:42:35.828 INFO [pool-61-thread-4] Message received from RabbitMQ: Hello Camel headers This is header
10:42:35.828 INFO [pool-61-thread-4] OK - expected This is header
10:42:35.828 INFO [pool-61-thread-4] OK - expected Hello Camel
10:42:40.790 INFO [pool-61-thread-6] Message received from RabbitMQ: Hello Camel headers This is header
10:42:40.790 INFO [Camel (camel-1) thread #1 - timer://testTimer] Message sent to RabbitMQ: Hello Camel headers This is header
10:42:40.791 INFO [pool-61-thread-6] OK - expected This is header
10:42:40.791 INFO [pool-61-thread-6] OK - expected Hello Camel 
```
No additional bundles are needed