### PR TITLE
chore: set proper name to examples

### DIFF
--- a/tests/examples/blueprint-dsl-only/pom.xml
+++ b/tests/examples/blueprint-dsl-only/pom.xml
@@ -28,5 +28,5 @@
     </parent>
 
     <artifactId>camel-karaf-examples-blueprint-dsl-only-test</artifactId>
-    <name>Apache Camel :: Karaf :: Tests :: Samples :: Blueprint DSL Only</name>
+    <name>Apache Camel :: Karaf :: Tests :: Examples :: Blueprint DSL Only</name>
 </project>

--- a/tests/examples/java-dsl-only/pom.xml
+++ b/tests/examples/java-dsl-only/pom.xml
@@ -28,5 +28,5 @@
     </parent>
 
     <artifactId>camel-karaf-examples-java-dsl-only-test</artifactId>
-    <name>Apache Camel :: Karaf :: Tests :: Samples :: Java DSL Only</name>
+    <name>Apache Camel :: Karaf :: Tests :: Examples :: Java DSL Only</name>
 </project>

--- a/tests/examples/mixed/pom.xml
+++ b/tests/examples/mixed/pom.xml
@@ -28,5 +28,5 @@
     </parent>
 
     <artifactId>camel-karaf-examples-mixed-test</artifactId>
-    <name>Apache Camel :: Karaf :: Tests :: Samples :: Mixed</name>
+    <name>Apache Camel :: Karaf :: Tests :: Examples :: Mixed</name>
 </project>


### PR DESCRIPTION
## Motivation

The name of the pom files of the examples were not properly set

## Modifications:

* set proper name to examples