### PR TITLE
Ref #289: Add SPI-Provider to all wrapped bundles with SPI services

### DIFF
--- a/features/pom.xml
+++ b/features/pom.xml
@@ -32,6 +32,10 @@
     <packaging>pom</packaging>
     <name>Apache Camel :: Karaf :: Features</name>
 
+    <properties>
+        <spi-consumer>SPI-Consumer=*</spi-consumer>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
@@ -71,6 +75,7 @@
                     <execution>
                         <goals>
                             <goal>ensure-wrap-bundle-version</goal>
+                            <goal>configure-wrap-spi-provider</goal>
                         </goals>
                         <configuration>
                             <featuresFilePath>file:${project.build.directory}/feature/camel-features.xml</featuresFilePath>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -158,13 +158,12 @@
     </feature>
 
     <feature name="awssdk" version="${aws-java-sdk2-version}" start-level="50">
-        <feature prerequisite="true">spifly</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/auth/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-core/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sdk-core/${aws-java-sdk2-version}$${spi-consumer}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-client-spi/${aws-java-sdk2-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}$${spi-provider}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/regions/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/utils/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/identity-spi/${aws-java-sdk2-version}</bundle>
@@ -338,7 +337,6 @@
     </feature>
     <feature name='camel-atmosphere-websocket' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-servlet</feature>
-        <feature prerequisite="true">spifly</feature>
         <!-- Wrap protocol used to work around the wrong version range used for the servlet API [2.5,4)  -->
         <bundle dependency="true">wrap:mvn:org.atmosphere/atmosphere-runtime/${atmosphere-version}$overwrite=merge&amp;Import-Package=jakarta.servlet;version:="[6,7)",*;resolution:=optional</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-atmosphere-websocket/${project.version}</bundle>
@@ -1037,7 +1035,6 @@
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4.1,5)'>netty</feature>
-        <feature prerequisite="true">spifly</feature>
         <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/1.127.1</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/api-common/2.28.0</bundle>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
@@ -1064,13 +1061,13 @@
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/2.36.0$Export-Package=com.google.longrunning*;version=2.36.0,*</bundle>
         <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/0.27.0</bundle>
         <bundle dependency='true'>wrap:mvn:io.grpc/grpc-stub/${grpc-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-netty/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-grpclb/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-googleapis/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-xds/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-services/${grpc-version}$${spi-provider}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-util/${grpc-version}$${spi-provider}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-netty/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-core/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-grpclb/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-googleapis/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-xds/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-services/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-util/${grpc-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub/${project.version}</bundle>
     </feature>
     <feature name='camel-google-secret-manager' version='${project.version}' start-level='50'>
@@ -1529,7 +1526,6 @@
         <bundle>mvn:org.apache.camel.karaf/camel-kamelet/${project.version}</bundle>
     </feature>
     <feature name='camel-kubernetes' version='${project.version}' start-level='50'>
-        <feature prerequisite="true">spifly</feature>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:io.fabric8/kubernetes-client/${kubernetes-client-version}</bundle>
@@ -1846,7 +1842,6 @@
         <bundle>mvn:org.apache.camel.karaf/camel-opensearch/${project.version}</bundle>
     </feature>
     <feature name='camel-openstack' version='${project.version}' start-level='50'>
-        <feature prerequisite="true">spifly</feature>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
         <feature version='[33,34)'>guava</feature>
@@ -2170,7 +2165,6 @@
         <bundle>mvn:org.apache.camel.karaf/camel-servlet/${project.version}</bundle>
     </feature>
     <feature name='camel-shiro' version='${project.version}' start-level='50'>
-        <feature prerequisite="true">spifly</feature>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.shiro/shiro-core/${shiro-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.shiro/shiro-event/${shiro-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -563,9 +563,6 @@
         <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
         <harmcrest.version>1.3_1</harmcrest.version>
         <geronimo-atinject.version>1.2</geronimo-atinject.version>
-
-        <spi-provider>SPI-Provider=*</spi-provider>
-        <spi-consumer>SPI-Consumer=*</spi-consumer>
     </properties>
 
     <dependencyManagement>

--- a/tooling/camel-karaf-feature-maven-plugin/pom.xml
+++ b/tooling/camel-karaf-feature-maven-plugin/pom.xml
@@ -53,6 +53,12 @@
         <!-- maven plugin -->
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractFeaturesMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractFeaturesMojo.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.feature.maven;
+
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.karaf.features.internal.model.Feature;
+import org.apache.karaf.features.internal.model.Features;
+import org.apache.karaf.features.internal.model.JaxbUtil;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+public abstract class AbstractFeaturesMojo extends AbstractMojo {
+
+    private static final String FILE_PROTOCOL = "file:";
+
+    private static final String DEFAULT_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>";
+    private static final String LICENCE_HEADER = """
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->""";
+
+    @Parameter(required = true)
+    private String featuresFilePath;
+
+    @Parameter
+    private String featuresFileResultPath;
+
+    public String getFeaturesFilePath() {
+        return featuresFilePath;
+    }
+
+    public String getFeaturesFileResultPath() {
+        return featuresFileResultPath;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        Features featuresData = JaxbUtil.unmarshal(getFeaturesFilePath(), false);
+        processFeatures(featuresData.getFeature());
+        marshal(featuresData);
+    }
+
+    private void marshal(Features featuresData) throws MojoExecutionException {
+        String outputPath = getFeaturesFileResultPath();
+        if (outputPath == null) {
+            outputPath = getFeaturesFilePath();
+        }
+        try (StringWriter writer = new StringWriter()) {
+            JaxbUtil.marshal(featuresData, writer);
+
+            String result = writer.toString().replace(DEFAULT_HEADER, LICENCE_HEADER);
+
+            Path path = Paths.get(outputPath.replaceFirst(FILE_PROTOCOL, ""));
+
+            Files.createDirectories(path.getParent());
+
+            Files.writeString(path, result);
+
+            getLog().info("File '%s' was successfully modified and saved".formatted(outputPath));
+        } catch (Exception e) {
+            getLog().error("File '%s' was successfully modified but an error occurred while saving it"
+                    .formatted(outputPath), e);
+            throw new MojoExecutionException(e);
+        }
+    }
+
+
+    private void processFeatures(List<Feature> features) {
+        for (Feature feature : features) {
+            processFeature(feature);
+        }
+    }
+
+    /**
+     * Process the given feature.
+     */
+    protected abstract void processFeature(Feature feature);
+}

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractWrapBundleMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractWrapBundleMojo.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.feature.maven;
+
+import org.apache.karaf.features.internal.model.Bundle;
+import org.apache.karaf.features.internal.model.Feature;
+
+public abstract class AbstractWrapBundleMojo extends AbstractFeaturesMojo {
+
+    private static final String WRAP_PROTOCOL = "wrap:mvn:";
+
+    @Override
+    protected void processFeature(Feature feature) {
+        boolean processed = false;
+        for (Bundle bundle : feature.getBundle()) {
+            String location = bundle.getLocation();
+            if (location != null && location.startsWith(WRAP_PROTOCOL)) {
+                processed |= processWrappedBundle(bundle);
+            }
+        }
+        if (processed) {
+            onFeatureUpdated(feature);
+        }
+    }
+
+    /**
+     * Called when a feature has been updated.
+     */
+    protected void onFeatureUpdated(Feature feature) {
+        // Do nothing by default
+    }
+
+    /**
+     * Process the given wrapped bundle.
+     *
+     * @param bundle the bundle
+     * @return {@code true} if the feature has been updated, {@code false} otherwise
+     */
+    protected abstract boolean processWrappedBundle(Bundle bundle);
+}

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractWrapBundleMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AbstractWrapBundleMojo.java
@@ -22,16 +22,15 @@ import org.apache.karaf.features.internal.model.Feature;
 
 public abstract class AbstractWrapBundleMojo extends AbstractFeaturesMojo {
 
-    private static final String WRAP_PROTOCOL = "wrap:mvn:";
-
     @Override
     protected void processFeature(Feature feature) {
         boolean processed = false;
         for (Bundle bundle : feature.getBundle()) {
-            String location = bundle.getLocation();
-            if (location != null && location.startsWith(WRAP_PROTOCOL)) {
-                processed |= processWrappedBundle(bundle);
+            WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+            if (wrappedBundle == null) {
+                continue;
             }
+            processed |= processWrappedBundle(wrappedBundle);
         }
         if (processed) {
             onFeatureUpdated(feature);
@@ -48,8 +47,8 @@ public abstract class AbstractWrapBundleMojo extends AbstractFeaturesMojo {
     /**
      * Process the given wrapped bundle.
      *
-     * @param bundle the bundle
+     * @param bundle     the wrapped bundle to process
      * @return {@code true} if the feature has been updated, {@code false} otherwise
      */
-    protected abstract boolean processWrappedBundle(Bundle bundle);
+    protected abstract boolean processWrappedBundle(WrappedBundle bundle);
 }

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/ConfigureWrapSpiProviderMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/ConfigureWrapSpiProviderMojo.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.feature.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipFile;
+
+import org.apache.karaf.features.internal.model.Bundle;
+import org.apache.karaf.features.internal.model.Dependency;
+import org.apache.karaf.features.internal.model.Feature;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+
+
+@Mojo(name = "configure-wrap-spi-provider", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class ConfigureWrapSpiProviderMojo extends AbstractWrapBundleMojo {
+
+    private static final Pattern WRAP_PROTOCOL = Pattern.compile("wrap:mvn:([^/]+)/([^/]+)/([^$]+)(\\$([^=]+=[^&]+)(&([^=]+=[^&]+))*)?");
+    private static final String SPI_PROVIDER = "SPI-Provider";
+    private static final String SPI_HEADER = "%s=*".formatted(SPI_PROVIDER);
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repositories;
+
+    @Override
+    protected void onFeatureUpdated(Feature feature) {
+        addSpiFlyIfAbsent(feature);
+    }
+
+    /**
+     * Add SpiFly to the dependencies of the given feature if it is not already present.
+     */
+    private static void addSpiFlyIfAbsent(Feature feature) {
+        if (!containsSpiFly(feature)) {
+            addSpiFly(feature);
+        }
+    }
+
+    /**
+     * Add SpiFly to the dependencies of the given feature.
+     */
+    private static void addSpiFly(Feature feature) {
+        Dependency dependency = new Dependency("spifly", null);
+        dependency.setPrerequisite(true);
+        feature.getFeature().add(dependency);
+    }
+
+    /**
+     * Check if the given feature contains SpiFly as part of its dependencies.
+     * @return {@code true} if the feature contains SpiFly, {@code false} otherwise.
+     */
+    private static boolean containsSpiFly(Feature feature) {
+        return feature.getFeature().stream().anyMatch(d -> "spifly".equals(d.getName()));
+    }
+
+    @Override
+    protected boolean processWrappedBundle(Bundle bundle) {
+        String location = bundle.getLocation();
+        Matcher matcher = WRAP_PROTOCOL.matcher(location);
+        if (matcher.matches()) {
+            String groupId = matcher.group(1);
+            String artifactId = matcher.group(2);
+            String version = matcher.group(3);
+            String options = matcher.group(4);
+            if (options != null && options.contains(SPI_PROVIDER)) {
+                return false;
+            } else if (provideSPI(groupId, artifactId, version)) {
+                addHeader(bundle, options);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Add the SPI-Provider header to the given bundle's location.
+     */
+    private static void addHeader(Bundle bundle, String options) {
+        String separator;
+        if (options == null) {
+            separator = "$";
+        } else if (options.endsWith("&") || options.endsWith("$")) {
+            separator = "";
+        } else {
+            separator = "&";
+        }
+        bundle.setLocation("%s%s%s".formatted(bundle.getLocation(), separator, SPI_HEADER));
+    }
+
+    /**
+     * Check if the given artifact corresponding to the given maven coordinates provides at least
+     * one implementation of service.
+     */
+    private boolean provideSPI(String groupId, String artifactId, String version) {
+        File file = resolveArtifact(groupId, artifactId, version);
+        if (file == null) {
+            getLog().warn("Could not download artifact %s:%s:%s".formatted(groupId, artifactId, version));
+            return false;
+        }
+        try {
+            return containsSPI(file);
+        } catch (IOException e) {
+            getLog().warn("Could not check artifact %s:%s:%s".formatted(groupId, artifactId, version), e);
+        }
+        return false;
+    }
+
+    /**
+     * Check if the given archive contains at least one implementation of a service.
+     */
+    private static boolean containsSPI(File archive) throws IOException {
+        try (ZipFile zip = new ZipFile(archive)) {
+            return zip.getEntry("META-INF/services") != null;
+        }
+    }
+
+    /**
+     * Resolve the artifact corresponding to the given maven coordinates from the repositories.
+     * @return the resolved file or null if the artifact could not be resolved.
+     */
+    private File resolveArtifact(String groupId, String artifactId, String version) {
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Resolving artifact %s:%s:%s".formatted(groupId, artifactId, version));
+        }
+        ArtifactRequest req = new ArtifactRequest()
+                .setRepositories(this.repositories)
+                .setArtifact(new DefaultArtifact(groupId, artifactId, "jar", version));
+        try {
+            return this.repoSystem.resolveArtifact(this.repoSession, req).getArtifact().getFile();
+        } catch (Exception e) {
+            getLog().warn("Artifact %s could not be resolved.".formatted(artifactId), e);
+        }
+        return null;
+    }
+}

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/WrappedBundle.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/WrappedBundle.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.feature.maven;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.karaf.features.internal.model.Bundle;
+
+public class WrappedBundle {
+
+    private static final Pattern WRAP_PROTOCOL = Pattern.compile("wrap:mvn:([^/]+)/([^/]+)/([^$]+|\\$\\{[^}]+})(\\$([^=]+=[^&]+|\\$\\{[^}]+}=[^&]|\\$\\{[^}]+})(&([^=]+=[^&]+|\\$\\{[^}]+}=[^&]|\\$\\{[^}]+}))*)?");
+
+    /**
+     * The group id of the bundle
+     */
+    private final String groupId;
+    /**
+     * The artifact id of the bundle
+     */
+    private final String artifactId;
+    /**
+     * The version of the bundle
+     */
+    private final String version;
+    /**
+     * The additional wrapping instructions provided in the WRAP URL
+     */
+    private final String instructions;
+    /**
+     * The underlying bundle
+     */
+    private final Bundle bundle;
+
+    private WrappedBundle(String groupId, String artifactId, String version, String options, Bundle bundle) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.instructions = options;
+        this.bundle = bundle;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public Bundle getBundle() {
+        return bundle;
+    }
+
+    /**
+     * Create a WrappedBundle from the given bundle.
+     * @return the WrappedBundle or {@code null} if the bundle is not a wrapped bundle
+     */
+    public static WrappedBundle fromBundle(Bundle bundle) {
+        String location = bundle.getLocation();
+        if (location == null) {
+            return null;
+        }
+        return fromLocation(location, bundle);
+    }
+
+    private static WrappedBundle fromLocation(String location, Bundle bundle) {
+        Matcher matcher = WRAP_PROTOCOL.matcher(location);
+        if (matcher.matches()) {
+            return new WrappedBundle(matcher.group(1), matcher.group(2), matcher.group(3), matcher.group(4), bundle);
+        }
+        return null;
+    }
+}

--- a/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleVersionMojoTest.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleVersionMojoTest.java
@@ -17,9 +17,11 @@
 package org.apache.camel.karaf.feature.maven;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import org.apache.karaf.features.internal.model.Bundle;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class EnsureWrapBundleVersionMojoTest {
 
@@ -27,68 +29,41 @@ public class EnsureWrapBundleVersionMojoTest {
 
     @Test
     void modifyLocationTest() throws Exception {
+        Bundle bundle = new Bundle();
         // add bundle version at the end as first wrap protocol option
-        String location = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0";
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0");
         String expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-Version=5.0.0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureVersionMojo.processLocation(wrappedBundle));
 
         // add bundle version at the end but not as first wrap protocol option
-        location = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge";
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge");
         expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Version=5.0.0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureVersionMojo.processLocation(wrappedBundle));
 
         // add bundle version before existing wrap protocol header that should be declared after
-        location = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0";
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
         expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Version=5.0.0&Export-Package=org.apache.olingo.*;version=5.0.0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureVersionMojo.processLocation(wrappedBundle));
 
         // original version won't work in Karaf
-        location = "wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0";
+        bundle.setLocation("wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0");
         expected = "wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0$Bundle-Version=0.0.0.v1-rev20240209-2_0_0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureVersionMojo.processLocation(wrappedBundle));
 
         // bundle version header is present but it won't work in Karaf
-        location = "wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0$Bundle-Version=v1-rev20240209-2.0.0";
+        bundle.setLocation("wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0$Bundle-Version=v1-rev20240209-2.0.0");
         expected = "wrap:mvn:com.google.apis/google-api-services-storage/v1-rev20240209-2.0.0$Bundle-Version=0.0.0.v1-rev20240209-2_0_0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
-
-        // bundle version header is present and points to the wrong value but it will
-        // work in Karaf
-        location = "mvn:commons-io/commons-io/2.15.1$Bundle-Version=2.15.0";
-        expected = "mvn:commons-io/commons-io/2.15.1$Bundle-Version=2.15.0";
-        assertEquals(expected, ensureVersionMojo.processLocation(location));
-    }
-
-    @Test
-    void getVersionStartIndexTest() {
-        assertEquals(51,
-                ensureVersionMojo.getVersionStartIndex("wrap:mvn:org.apache.httpcomponents.core5/httpcore5/5.2.1"));
-        assertEquals(51, ensureVersionMojo.getVersionStartIndex(
-                "wrap:mvn:org.eclipse.californium/element-connector/3.11.0$overwrite=merge&Import-Package=net.i2p.crypto.eddsa;resolution:=optional"));
-    }
-
-    @Test
-    void getVersionEndIndexTest() {
-        assertEquals(55,
-                ensureVersionMojo.getVersionEndIndex("wrap:mvn:org.apache.httpcomponents.core5/httpcore5/5.2.1"));
-        assertEquals(56, ensureVersionMojo.getVersionEndIndex(
-                "wrap:mvn:org.eclipse.californium/element-connector/3.11.0$overwrite=merge&Import-Package=net.i2p.crypto.eddsa;resolution:=optional"));
-    }
-
-    @Test
-    void getVersionTest() {
-        assertEquals("${google-oauth-client-version}", ensureVersionMojo.getVersion(
-                "wrap:mvn:com.google.oauth-client/google-oauth-client-jetty/${google-oauth-client-version}$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*"));
-
-        assertEquals("8.44.0.Final", ensureVersionMojo.getVersion("wrap:mvn:org.kie/kie-api/8.44.0.Final"));
-
-        assertEquals("5.0.0", ensureVersionMojo.getVersion(
-                "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0"));
-
-        assertEquals("${grpc-version}",
-                ensureVersionMojo.getVersion("wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}"));
-
-        assertEquals("1.63.0", ensureVersionMojo.getVersion("wrap:mvn:io.grpc/grpc-googleapis/1.63.0$SPI-Provider=*"));
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureVersionMojo.processLocation(wrappedBundle));
     }
 
     @Test

--- a/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/WrappedBundleTest.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/WrappedBundleTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.feature.maven;
+
+import org.apache.karaf.features.internal.model.Bundle;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The unit test class for {@link WrappedBundle}.
+ */
+class WrappedBundleTest {
+
+    private final Bundle bundle = new Bundle();
+
+    @Test
+    void fromBundleTest() {
+        bundle.setLocation("mvn:commons-io/commons-io/2.15.1$Bundle-Version=2.15.0");
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNull(wrappedBundle);
+    }
+
+    @Test
+    void getGroupIdTest() {
+        bundle.setLocation("wrap:mvn:com.google.oauth-client/google-oauth-client-jetty/${google-oauth-client-version}$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*");
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("com.google.oauth-client", wrappedBundle.getGroupId());
+
+        bundle.setLocation("wrap:mvn:org.kie/kie-api/8.44.0.Final");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("org.kie", wrappedBundle.getGroupId());
+
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("org.apache.olingo", wrappedBundle.getGroupId());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("io.grpc", wrappedBundle.getGroupId());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-googleapis/1.63.0$SPI-Provider=*");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("io.grpc", wrappedBundle.getGroupId());
+    }
+
+    @Test
+    void getArtifactIdTest() {
+        bundle.setLocation("wrap:mvn:com.google.oauth-client/google-oauth-client-jetty/${google-oauth-client-version}$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*");
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("google-oauth-client-jetty", wrappedBundle.getArtifactId());
+
+        bundle.setLocation("wrap:mvn:org.kie/kie-api/8.44.0.Final");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("kie-api", wrappedBundle.getArtifactId());
+
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("odata-server-core", wrappedBundle.getArtifactId());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("grpc-core", wrappedBundle.getArtifactId());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-googleapis/1.63.0$SPI-Provider=*");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("grpc-googleapis", wrappedBundle.getArtifactId());
+    }
+
+    @Test
+    void getVersionTest() {
+        bundle.setLocation("wrap:mvn:com.google.oauth-client/google-oauth-client-jetty/${google-oauth-client-version}$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*");
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("${google-oauth-client-version}", wrappedBundle.getVersion());
+
+        bundle.setLocation("wrap:mvn:org.kie/kie-api/8.44.0.Final");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("8.44.0.Final", wrappedBundle.getVersion());
+
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("5.0.0", wrappedBundle.getVersion());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("${grpc-version}", wrappedBundle.getVersion());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-googleapis/1.63.0$SPI-Provider=*");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("1.63.0", wrappedBundle.getVersion());
+    }
+
+    @Test
+    void getInstructionsTest() {
+        bundle.setLocation("wrap:mvn:com.google.oauth-client/google-oauth-client-jetty/${google-oauth-client-version}$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*");
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("$overwrite=merge&Import-Package=com.sun.net.httpserver;resolution:=optional,*", wrappedBundle.getInstructions());
+
+        bundle.setLocation("wrap:mvn:org.kie/kie-api/8.44.0.Final");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertNull(wrappedBundle.getInstructions());
+
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0", wrappedBundle.getInstructions());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-core/${grpc-version}$${spi-provider}");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("$${spi-provider}", wrappedBundle.getInstructions());
+
+        bundle.setLocation("wrap:mvn:io.grpc/grpc-googleapis/1.63.0$SPI-Provider=*");
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals("$SPI-Provider=*", wrappedBundle.getInstructions());
+    }
+}

--- a/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
@@ -1,0 +1,59 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>tooling</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>camel-karaf-maven-plugin-integration-test</artifactId>
+    <packaging>pom</packaging>
+    <name>Apache Camel :: Karaf :: Tooling :: Maven Plugin Integration Test</name>
+
+    <properties>
+        <maven-invoker-plugin-version>3.7.0</maven-invoker-plugin-version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>${maven-invoker-plugin-version}</version>
+                <configuration>
+                    <projectsDirectory>src/it</projectsDirectory>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <pomIncludes>
+                        <pomInclude>**/pom.xml</pomInclude>
+                    </pomIncludes>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/pom.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.camel.karaf</groupId>
+    <artifactId>camel-karaf-feature-maven-plugin-configure-spi-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.camel.karaf</groupId>
+                <artifactId>camel-karaf-feature-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>configure-wrap-spi-provider</goal>
+                        </goals>
+                        <configuration>
+                            <featuresFilePath>file:${project.basedir}/src/main/feature/features.xml</featuresFilePath>
+                            <featuresFileResultPath>file:${project.build.directory}/feature/result.xml</featuresFileResultPath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/src/main/feature/expected.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/src/main/feature/expected.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<features name="test-configure-spi" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+    <feature name="without-wrappers" version="1.0.0">
+        <feature>jackson</feature>
+        <feature version="[4.1,5)">netty</feature>
+        <bundle dependency="true">mvn:com.datastax.oss/native-protocol/1.5.1</bundle>
+        <bundle dependency="true">mvn:com.typesafe/config/1.4.1</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-with-spifly" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <feature prerequisite="true">spifly</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9$SPI-Provider=*</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-without-header" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <feature prerequisite="true">spifly</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9$SPI-Provider=*</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-with-header" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <feature prerequisite="true">spifly</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9$Bundle-Version=2.9.0&amp;SPI-Provider=*</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-without-spi-provider" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <bundle dependency="true">mvn:com.google.code.gson/gson/2.10.1</bundle>
+        <bundle dependency="true">wrap:mvn:com.slack.api/slack-api-client/1.39.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.slack.api/slack-api-model/1.39.0$Bundle-Version=1.39.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp3/okhttp/3.14.9$Bundle-Version=3.14.9</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-slack/4.6.0-SNAPSHOT</bundle>
+    </feature>
+</features>

--- a/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/src/main/feature/features.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/src/main/feature/features.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<features name="test-configure-spi" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
+    <feature name="without-wrappers" version="1.0.0">
+        <feature>jackson</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle dependency="true">mvn:com.datastax.oss/native-protocol/1.5.1</bundle>
+        <bundle dependency='true'>mvn:com.typesafe/config/1.4.1</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-with-spifly" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <feature prerequisite="true">spifly</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-without-header" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-with-spi-provider-with-header" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop-core/2.9$Bundle-Version=2.9.0</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fop/4.6.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="with-wrapper-without-spi-provider" version="1.0.0">
+        <feature version="[4.6,4.7)">camel-core</feature>
+        <bundle dependency="true">mvn:com.google.code.gson/gson/2.10.1</bundle>
+        <bundle dependency="true">wrap:mvn:com.slack.api/slack-api-client/1.39.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.slack.api/slack-api-model/1.39.0$Bundle-Version=1.39.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp3/okhttp/3.14.9$Bundle-Version=3.14.9</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-slack/4.6.0-SNAPSHOT</bundle>
+    </feature>
+</features>

--- a/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/verify.groovy
+++ b/tooling/camel-karaf-maven-plugin-integration-test/src/it/configure-spi/verify.groovy
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+
+Path actual = Paths.get(basedir.getAbsolutePath(), "target/feature/result.xml");
+
+if (!Files.exists(actual)) {
+    throw new FileNotFoundException("Could not find generated file: $actual");
+}
+
+Path expected = Paths.get(basedir.getAbsolutePath(), "src/main/feature/expected.xml");
+
+if (!Files.exists(actual)) {
+    throw new FileNotFoundException("Could not find expected file: $expected");
+}
+
+String actualContent = Files.readString(actual);
+String expectedContent = Files.readString(expected);
+
+if (actualContent != expectedContent) {
+    throw new Exception("Expected and actual features files are not equal");
+}
+
+return true;

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -30,6 +30,7 @@
     
     <modules>
         <module>camel-karaf-feature-maven-plugin</module>
+        <module>camel-karaf-maven-plugin-integration-test</module>
     </modules>
     
 </project>


### PR DESCRIPTION
fixes #289 

## Motivation

Managing SPI with wrapped bundles can be cumbersome and hard to maintain, so we need to automate it

## Modifications:

* Add a new maven goal to the existing plugin to automatically add the header when a wrapped bundle contains some SPI and add spifly to the feature