### PR TITLE
Ref #350: Replace hard-coded versions with maven properties

### DIFF
--- a/components/camel-activemq/pom.xml
+++ b/components/camel-activemq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             com.thoughtworks.xstream*;resolution:=optional,
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-activemq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-amqp/pom.xml
+++ b/components/camel-amqp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-amqp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-arangodb/pom.xml
+++ b/components/camel-arangodb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             !com.arangodb*,
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-arangodb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-as2/pom.xml
+++ b/components/camel-as2/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-as2</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-as2-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-asn1/pom.xml
+++ b/components/camel-asn1/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-asn1</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-asterisk/pom.xml
+++ b/components/camel-asterisk/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-asterisk</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-atmosphere-websocket/pom.xml
+++ b/components/camel-atmosphere-websocket/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-atmosphere-websocket</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-atom/pom.xml
+++ b/components/camel-atom/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-atom</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-attachments/pom.xml
+++ b/components/camel-attachments/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-attachments</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-avro/pom.xml
+++ b/components/camel-avro/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-avro</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws-cloudtrail/pom.xml
+++ b/components/camel-aws/camel-aws-cloudtrail/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws-cloudtrail</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws-config/pom.xml
+++ b/components/camel-aws/camel-aws-config/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws-config</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws-secrets-manager/pom.xml
+++ b/components/camel-aws/camel-aws-secrets-manager/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws-secrets-manager</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws-xray/pom.xml
+++ b/components/camel-aws/camel-aws-xray/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws-xray</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-athena</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-cw/pom.xml
+++ b/components/camel-aws/camel-aws2-cw/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-cw</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-ddb/pom.xml
+++ b/components/camel-aws/camel-aws2-ddb/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-ddb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-ec2/pom.xml
+++ b/components/camel-aws/camel-aws2-ec2/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-ec2</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-ecs/pom.xml
+++ b/components/camel-aws/camel-aws2-ecs/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-ecs</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-eks/pom.xml
+++ b/components/camel-aws/camel-aws2-eks/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-eks</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-eventbridge/pom.xml
+++ b/components/camel-aws/camel-aws2-eventbridge/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-eventbridge</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-iam/pom.xml
+++ b/components/camel-aws/camel-aws2-iam/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-iam</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-kinesis</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-kms/pom.xml
+++ b/components/camel-aws/camel-aws2-kms/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-kms</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-lambda/pom.xml
+++ b/components/camel-aws/camel-aws2-lambda/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-lambda</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-mq/pom.xml
+++ b/components/camel-aws/camel-aws2-mq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-mq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-msk/pom.xml
+++ b/components/camel-aws/camel-aws2-msk/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-msk</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-redshift/pom.xml
+++ b/components/camel-aws/camel-aws2-redshift/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-redshift</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-s3/pom.xml
+++ b/components/camel-aws/camel-aws2-s3/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-s3</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-ses</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-sns/pom.xml
+++ b/components/camel-aws/camel-aws2-sns/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-sns</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-sqs/pom.xml
+++ b/components/camel-aws/camel-aws2-sqs/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-sqs</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-step-functions/pom.xml
+++ b/components/camel-aws/camel-aws2-step-functions/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-step-functions</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-sts/pom.xml
+++ b/components/camel-aws/camel-aws2-sts/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-sts</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-timestream/pom.xml
+++ b/components/camel-aws/camel-aws2-timestream/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-timestream</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-aws/camel-aws2-translate/pom.xml
+++ b/components/camel-aws/camel-aws2-translate/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-translate</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-cosmosdb/pom.xml
+++ b/components/camel-azure/camel-azure-cosmosdb/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-cosmosdb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-eventhubs/pom.xml
+++ b/components/camel-azure/camel-azure-eventhubs/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-eventhubs</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-files/pom.xml
+++ b/components/camel-azure/camel-azure-files/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-files</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-key-vault/pom.xml
+++ b/components/camel-azure/camel-azure-key-vault/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-key-vault</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-schema-registry/pom.xml
+++ b/components/camel-azure/camel-azure-schema-registry/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-schema-registry</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-servicebus/pom.xml
+++ b/components/camel-azure/camel-azure-servicebus/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-servicebus</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-storage-blob/pom.xml
+++ b/components/camel-azure/camel-azure-storage-blob/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-storage-blob</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-storage-datalake/pom.xml
+++ b/components/camel-azure/camel-azure-storage-datalake/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-storage-datalake</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-azure/camel-azure-storage-queue/pom.xml
+++ b/components/camel-azure/camel-azure-storage-queue/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-azure-storage-queue</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-barcode/pom.xml
+++ b/components/camel-barcode/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-barcode</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-base64/pom.xml
+++ b/components/camel-base64/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-base64</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-bean-validator/pom.xml
+++ b/components/camel-bean-validator/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-bean-validator</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-bean</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-bindy/pom.xml
+++ b/components/camel-bindy/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-bindy</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-blueprint/pom.xml
+++ b/components/camel-blueprint/pom.xml
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-xml</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.karaf</groupId>
@@ -65,22 +65,22 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-bean</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.bundle</groupId>
             <artifactId>org.apache.karaf.bundle.core</artifactId>
-            <version>${karaf.version}</version>
+            <version>${karaf-version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-package-maven-plugin</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-version}</version>
                 <executions>
                     <execution>
                         <id>jaxb-list</id>
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-eip-documentation-enricher-maven-plugin</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-version}</version>
                 <executions>
                     <execution>
                         <id>eip-documentation-enricher</id>
@@ -257,7 +257,7 @@
                                         <artifactItem>
                                             <groupId>org.apache.camel</groupId>
                                             <artifactId>camel-api</artifactId>
-                                            <version>${camel.version}</version>
+                                            <version>${camel-version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
@@ -266,7 +266,7 @@
                                         <artifactItem>
                                             <groupId>org.apache.camel</groupId>
                                             <artifactId>camel-core-model</artifactId>
-                                            <version>${camel.version}</version>
+                                            <version>${camel-version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
@@ -276,7 +276,7 @@
                                         <artifactItem>
                                             <groupId>org.apache.camel</groupId>
                                             <artifactId>camel-core-xml</artifactId>
-                                            <version>${camel.version}</version>
+                                            <version>${camel-version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
@@ -285,7 +285,7 @@
                                         <artifactItem>
                                             <groupId>org.apache.camel</groupId>
                                             <artifactId>camel-util</artifactId>
-                                            <version>${camel.version}</version>
+                                            <version>${camel-version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
@@ -294,7 +294,7 @@
                                         <artifactItem>
                                             <groupId>org.apache.camel</groupId>
                                             <artifactId>camel-spring-xml</artifactId>
-                                            <version>${camel.version}</version>
+                                            <version>${camel-version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>

--- a/components/camel-bonita/pom.xml
+++ b/components/camel-bonita/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-bonita</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-box/pom.xml
+++ b/components/camel-box/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-box</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-box-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-braintree</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-browse/pom.xml
+++ b/components/camel-browse/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-browse</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-caffeine/pom.xml
+++ b/components/camel-caffeine/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-caffeine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cassandraql</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cbor/pom.xml
+++ b/components/camel-cbor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cbor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-chatscript/pom.xml
+++ b/components/camel-chatscript/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-chatscript</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-chunk/pom.xml
+++ b/components/camel-chunk/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-chunk</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cloudevents/pom.xml
+++ b/components/camel-cloudevents/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cloudevents</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cm-sms/pom.xml
+++ b/components/camel-cm-sms/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cm-sms</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-coap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cometd/pom.xml
+++ b/components/camel-cometd/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cometd</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-consul/pom.xml
+++ b/components/camel-consul/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-consul</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-controlbus/pom.xml
+++ b/components/camel-controlbus/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-controlbus</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-couchbase/pom.xml
+++ b/components/camel-couchbase/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-couchbase</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-couchdb/pom.xml
+++ b/components/camel-couchdb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-couchdb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cron/pom.xml
+++ b/components/camel-cron/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cron</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-crypto/pom.xml
+++ b/components/camel-crypto/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-crypto</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-csimple-joor/pom.xml
+++ b/components/camel-csimple-joor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-csimple-joor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-csv/pom.xml
+++ b/components/camel-csv/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-csv</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -35,16 +35,16 @@
     <properties>
         <camel.osgi.export>
             org.apache.camel.component.cxf.osgi;version=${project.version},
-            org.apache.camel.component.cxf.common;version=${camel.version},
-            org.apache.camel.component.cxf.common.header;version=${camel.version},
-            org.apache.camel.component.cxf.common.message;version=${camel.version},
-            org.apache.camel.component.cxf.converter;version=${camel.version},
-            org.apache.camel.component.cxf.util;version=${camel.version},
+            org.apache.camel.component.cxf.common;version=${camel-version},
+            org.apache.camel.component.cxf.common.header;version=${camel-version},
+            org.apache.camel.component.cxf.common.message;version=${camel-version},
+            org.apache.camel.component.cxf.converter;version=${camel-version},
+            org.apache.camel.component.cxf.util;version=${camel-version},
             org.apache.camel.component.cxf.bus.blueprint;version=${project.version},
             org.apache.camel.component.cxf.bus.osgi;version=${project.version},
             org.apache.camel.component.cxf.configuration.blueprint;version=${project.version},
             org.apache.camel.component.cxf.helpers;version=${project.version},
-            org.apache.camel.component.cxf.jaxrs;version="${camel.version}",
+            org.apache.camel.component.cxf.jaxrs;version="${camel-version}",
             org.apache.camel.component.cxf.ext.logging.osgi;version=${project.version},
             org.apache.camel.component.cxf.jaxrs.blueprint;version=${project.version},
             org.apache.camel.component.cxf.jaxws.blueprint;version=${project.version},
@@ -57,20 +57,20 @@
             org.apache.camel.component.cxf.transport.http_jetty.osgi;version=${project.version},
             org.apache.camel.component.cxf.ws.addressing.blueprint;version=${project.version},
             org.apache.camel.component.cxf.ws.policy.blueprint;version=${project.version},
-            org.apache.camel.component.cxf.feature;version=${camel.version},
-            org.apache.camel.component.cxf.interceptors;version=${camel.version},
-            org.apache.camel.component.cxf.jaxws;version=${camel.version},
-            org.apache.camel.component.cxf.transport;version=${camel.version},
-            org.apache.camel.component.cxf.transport.header;version=${camel.version},
-            org.apache.camel.component.cxf.transport.message;version=${camel.version},
+            org.apache.camel.component.cxf.feature;version=${camel-version},
+            org.apache.camel.component.cxf.interceptors;version=${camel-version},
+            org.apache.camel.component.cxf.jaxws;version=${camel-version},
+            org.apache.camel.component.cxf.transport;version=${camel-version},
+            org.apache.camel.component.cxf.transport.header;version=${camel-version},
+            org.apache.camel.component.cxf.transport.message;version=${camel-version},
             org.apache.camel.component.cxf.binding.soap.blueprint;version=${project.version},
             org.apache.cxf.*;version=${cxf-version},
         </camel.osgi.export>
         <camel.osgi.activator>org.apache.camel.component.cxf.osgi.MainActivator</camel.osgi.activator>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cxf.spring.*;resolution:=optional;${camel.osgi.import.camel.version},
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cxf.spring.*;resolution:=optional;${camel-osgi-import-camel-version},
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             com.sun.xml.messaging.saaj.soap;resolution:=optional,
             com.sun.xml.internal.messaging.saaj.soap;resolution:=optional,
@@ -80,26 +80,26 @@
             com.sun.tools*;resolution:=optional,
             com.sun.xml*;resolution:=optional,
             com.sun.codemodel.writer;resolution:=optional,
-            org.slf4j*;resolution:=optional;version="${camel.osgi.slf4j.version}",
-            net.sf.cglib*;resolution:=optional;version="${camel.cglib.osgi.version}",
-            org.springframework.aop*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.springframework.beans*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.springframework.context*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.springframework.core*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.springframework.util*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.springframework.web*;resolution:=optional;version="${camel.osgi.spring.version}",
-            org.objectweb.asm*;resolution:=optional;version="${camel.osgi.asm.version}",
-            jakarta.activation;version="${camel.osgi.jakarta.activation.version}",
-            jakarta.annotation;version="${camel.osgi.jakarta.annotation.version}",
-            jakarta.xml.ws*;version="${camel.osgi.jakarta.xml.ws.version}",
-            jakarta.xml.bind*;version="${camel.osgi.jakarta.bind.version}",
-            jakarta.validation*;resolution:=optional;version="${camel.validation.api.package.version}",
-            jakarta.jws*;version="${camel.osgi.jakarta.jwsapi.version}",
-            jakarta.ws.rs*;version="${camel.osgi.jakarta.ws.rs.version}",
-            jakarta.xml.soap*;version="${camel.osgi.saaj.version}",
-            jakarta.servlet*;version="${camel.osgi.jakarta.servlet.version}",
-            org.eclipse.jetty*;version="${camel.jetty.osgi.version}",
-            org.glassfish.jaxb.runtime.v2;version="${camel.osgi.jakarta.bind.version}",
+            org.slf4j*;resolution:=optional;version="${camel-osgi-slf4j-version}",
+            net.sf.cglib*;resolution:=optional;version="${camel-osgi-cglib-version}",
+            org.springframework.aop*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.beans*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.context*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.core*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.util*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.web*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.objectweb.asm*;resolution:=optional;version="${camel-osgi-asm-version}",
+            jakarta.activation;version="${camel-osgi-jakarta-activation-version}",
+            jakarta.annotation;version="${camel-osgi-jakarta-annotation-version}",
+            jakarta.xml.ws*;version="${camel-osgi-jakarta-xml-ws-version}",
+            jakarta.xml.bind*;version="${camel-osgi-jakarta-bind-version}",
+            jakarta.validation*;resolution:=optional;version="${camel-osgi-jakarta-validation-version}",
+            jakarta.jws*;version="${camel-osgi-jakarta-jws-version}",
+            jakarta.ws.rs*;version="${camel-osgi-jakarta-ws-rs-version}",
+            jakarta.xml.soap*;version="${camel-osgi-saaj-version}",
+            jakarta.servlet*;version="${camel-osgi-jakarta-servlet-version}",
+            org.eclipse.jetty*;version="${camel-osgi-jetty-version}",
+            org.glassfish.jaxb.runtime.v2;version="${camel-osgi-jakarta-bind-version}",
             javax.cache*;resolution:=optional,
             org.apache.cxf.tools*;resolution:=optional,
             org.apache.xml.resolver*;resolution:=optional,
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-rest</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -339,7 +339,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-soap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -350,7 +350,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-transport</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cxf/camel-cxf-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-blueprint/pom.xml
@@ -36,19 +36,19 @@
             org.apache.camel.component.cxf.blueprint.helpers;version=${project.version},
             org.apache.camel.component.cxf.blueprint.jaxrs;version=${project.version},
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cxf.helpers;${camel.osgi.import.camel.version},
-            org.apache.camel.component.cxf.configuration.blueprint;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cxf.helpers;${camel-osgi-import-camel-version},
+            org.apache.camel.component.cxf.configuration.blueprint;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
-            jakarta.xml.bind*;version="${camel.osgi.jakarta.bind.version}",
+            jakarta.xml.bind*;version="${camel-osgi-jakarta-bind-version}",
             org.apache.aries.blueprint,
             org.w3c*,
             org.osgi.util*,
             org.osgi.service*,
             org.osgi.framework*,
             org.apache.aries.blueprint*,
-            org.apache.cxf.*;version="${camel.osgi.cxf.version}",
+            org.apache.cxf.*;version="${camel-osgi-cxf-version}",
             org.slf4j
         </camel.osgi.import>
     </properties>
@@ -58,12 +58,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-soap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-rest</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
 
         <!-- OSGi, Blueprint -->

--- a/components/camel-cxf/camel-cxf-spring-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-all/pom.xml
@@ -34,28 +34,28 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel.component.cxf.spring;version=${camel.version},
-            org.apache.camel.component.cxf.spring.jaxrs;version=${camel.version},
-            org.apache.camel.component.cxf.spring.jaxws;version=${camel.version},
-            org.apache.camel.component.cxf.spring.transport;version=${camel.version}
+            org.apache.camel.component.cxf.spring;version=${camel-version},
+            org.apache.camel.component.cxf.spring.jaxrs;version=${camel-version},
+            org.apache.camel.component.cxf.spring.jaxws;version=${camel-version},
+            org.apache.camel.component.cxf.spring.transport;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
-            org.springframework*;version="${camel.osgi.spring.version}",
-            org.springframework.beans*;version="${camel.osgi.spring.version}",
-            org.springframework.context*;version="${camel.osgi.spring.version}",
-            org.springframework.core*;version="${camel.osgi.spring.version}",
-            org.springframework.util*;version="${camel.osgi.spring.version}",
-            org.springframework.web*;version="${camel.osgi.spring.version}",
-            org.apache.cxf.*;version="${camel.osgi.cxf.version}",
-            jakarta.activation;version="${camel.osgi.jakarta.activation.version}",
-            jakarta.annotation;version="${camel.osgi.jakarta.annotation.version}",
-            jakarta.xml.ws*;version="${camel.osgi.jakarta.xml.ws.version}",
-            jakarta.xml.bind*;version="${camel.osgi.jakarta.bind.version}",
-            jakarta.validation*;resolution:=optional;version="${camel.validation.api.package.version}",
-            jakarta.jws*;version="${camel.osgi.jakarta.jwsapi.version}",
-            jakarta.ws.rs*;version="${camel.osgi.jakarta.ws.rs.version}",
-            jakarta.xml.soap*;version="${camel.osgi.saaj.version}",
-            jakarta.servlet*;version="${camel.osgi.jakarta.servlet.version}",
+            org.springframework*;version="${camel-osgi-spring-version}",
+            org.springframework.beans*;version="${camel-osgi-spring-version}",
+            org.springframework.context*;version="${camel-osgi-spring-version}",
+            org.springframework.core*;version="${camel-osgi-spring-version}",
+            org.springframework.util*;version="${camel-osgi-spring-version}",
+            org.springframework.web*;version="${camel-osgi-spring-version}",
+            org.apache.cxf.*;version="${camel-osgi-cxf-version}",
+            jakarta.activation;version="${camel-osgi-jakarta-activation-version}",
+            jakarta.annotation;version="${camel-osgi-jakarta-annotation-version}",
+            jakarta.xml.ws*;version="${camel-osgi-jakarta-xml-ws-version}",
+            jakarta.xml.bind*;version="${camel-osgi-jakarta-bind-version}",
+            jakarta.validation*;resolution:=optional;version="${camel-osgi-jakarta-validation-version}",
+            jakarta.jws*;version="${camel-osgi-jakarta-jws-version}",
+            jakarta.ws.rs*;version="${camel-osgi-jakarta-ws-rs-version}",
+            jakarta.xml.soap*;version="${camel-osgi-saaj-version}",
+            jakarta.servlet*;version="${camel-osgi-jakarta-servlet-version}",
             javax.xml*,
         </camel.osgi.import>
     </properties>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-spring-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-spring-rest</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-spring-soap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-spring-transport</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
@@ -36,11 +36,11 @@
         <camel.osgi.export>
             org.apache.camel.component.cxf.transport.blueprint;version=${project.version},
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cxf.helpers;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cxf.helpers;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
-            jakarta.xml.bind*;version="${camel.osgi.jakarta.bind.version}",
+            jakarta.xml.bind*;version="${camel-osgi-jakarta-bind-version}",
             org.apache.aries.blueprint,
             org.slf4j
         </camel.osgi.import>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-transport</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
 
         <!-- OSGi, Blueprint -->

--- a/components/camel-dataformat/pom.xml
+++ b/components/camel-dataformat/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dataformat</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-dataset/pom.xml
+++ b/components/camel-dataset/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dataset</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-datasonnet/pom.xml
+++ b/components/camel-datasonnet/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-datasonnet</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-debug/pom.xml
+++ b/components/camel-debug/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-debug</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-digitalocean/pom.xml
+++ b/components/camel-digitalocean/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-digitalocean</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-direct/pom.xml
+++ b/components/camel-direct/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-direct</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-directvm/pom.xml
+++ b/components/camel-directvm/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel.karaf.component.directvm.*;version=${camel.version}
+            org.apache.camel.karaf.component.directvm.*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-package-maven-plugin</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-version}</version>
                 <configuration>
                     <!-- set to true to make build fail fast if missing documentation in docs file -->
                     <failFast>false</failFast>
@@ -79,7 +79,7 @@
                     <dependency>
                         <groupId>org.apache.camel</groupId>
                         <artifactId>camel-core-model</artifactId>
-                        <version>${camel.version}</version>
+                        <version>${camel-version}</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>

--- a/components/camel-disruptor/pom.xml
+++ b/components/camel-disruptor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-disruptor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-djl/pom.xml
+++ b/components/camel-djl/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-djl</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-dns/pom.xml
+++ b/components/camel-dns/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dns</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-docker</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-drill/pom.xml
+++ b/components/camel-drill/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-drill</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-dropbox/pom.xml
+++ b/components/camel-dropbox/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dropbox</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-dynamic-router/pom.xml
+++ b/components/camel-dynamic-router/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dynamic-router</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ehcache/pom.xml
+++ b/components/camel-ehcache/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ehcache</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-elasticsearch-rest-client/pom.xml
+++ b/components/camel-elasticsearch-rest-client/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-elasticsearch-rest-client</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-elasticsearch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-elytron/pom.xml
+++ b/components/camel-elytron/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-elytron</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-etcd3/pom.xml
+++ b/components/camel-etcd3/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-etcd3</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-exec/pom.xml
+++ b/components/camel-exec/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-exec</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-fastjson/pom.xml
+++ b/components/camel-fastjson/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-fastjson</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-file-watch/pom.xml
+++ b/components/camel-file-watch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file-watch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-file/pom.xml
+++ b/components/camel-file/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-flatpack/pom.xml
+++ b/components/camel-flatpack/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-flatpack</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-flink/pom.xml
+++ b/components/camel-flink/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-flink</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-fop/pom.xml
+++ b/components/camel-fop/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-fop</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-freemarker/pom.xml
+++ b/components/camel-freemarker/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-freemarker</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ftp/pom.xml
+++ b/components/camel-ftp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ftp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-geocoder/pom.xml
+++ b/components/camel-geocoder/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-geocoder</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-git/pom.xml
+++ b/components/camel-git/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-git</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-github/pom.xml
+++ b/components/camel-github/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-github</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-bigquery/pom.xml
+++ b/components/camel-google/camel-google-bigquery/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-bigquery</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-calendar/pom.xml
+++ b/components/camel-google/camel-google-calendar/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-calendar</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-drive/pom.xml
+++ b/components/camel-google/camel-google-drive/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-drive</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-functions/pom.xml
+++ b/components/camel-google/camel-google-functions/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             com.google.common*;version="[33,34)",
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-functions</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-mail/pom.xml
+++ b/components/camel-google/camel-google-mail/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             com.google.common.base*;version="[33,34)",
             *
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-mail</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-pubsub</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-secret-manager/pom.xml
+++ b/components/camel-google/camel-google-secret-manager/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-secret-manager</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-sheets/pom.xml
+++ b/components/camel-google/camel-google-sheets/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-sheets</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-google/camel-google-storage/pom.xml
+++ b/components/camel-google/camel-google-storage/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-storage</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-grape/pom.xml
+++ b/components/camel-grape/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-grape</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-graphql/pom.xml
+++ b/components/camel-graphql/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-graphql</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-grok/pom.xml
+++ b/components/camel-grok/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-grok</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-groovy/pom.xml
+++ b/components/camel-groovy/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-groovy</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-grpc</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-gson/pom.xml
+++ b/components/camel-gson/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-gson</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-guava-eventbus/pom.xml
+++ b/components/camel-guava-eventbus/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-guava-eventbus</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-hashicorp-vault/pom.xml
+++ b/components/camel-hashicorp-vault/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-hashicorp-vault</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-hazelcast/pom.xml
+++ b/components/camel-hazelcast/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             javax.cache;resolution:=optional,
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-hazelcast</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-headersmap/pom.xml
+++ b/components/camel-headersmap/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-headersmap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-hl7/pom.xml
+++ b/components/camel-hl7/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             ca.uhn.hl7v2.model.*;resolution:=optional,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-hl7</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-http-base/pom.xml
+++ b/components/camel-http-base/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-http-base</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-http-common/pom.xml
+++ b/components/camel-http-common/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             jakarta.servlet*;resolution:=optional,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-http-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-http/pom.xml
+++ b/components/camel-http/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-http</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ical/pom.xml
+++ b/components/camel-ical/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ical</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-iec60870/pom.xml
+++ b/components/camel-iec60870/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-iec60870</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ignite/pom.xml
+++ b/components/camel-ignite/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ignite</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-influxdb/pom.xml
+++ b/components/camel-influxdb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-influxdb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-influxdb2/pom.xml
+++ b/components/camel-influxdb2/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-influxdb2</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-irc/pom.xml
+++ b/components/camel-irc/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-irc</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ironmq/pom.xml
+++ b/components/camel-ironmq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ironmq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jackson-avro/pom.xml
+++ b/components/camel-jackson-avro/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jackson-avro</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jackson-protobuf/pom.xml
+++ b/components/camel-jackson-protobuf/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jackson-protobuf</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jackson/pom.xml
+++ b/components/camel-jackson/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jackson</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jacksonxml/pom.xml
+++ b/components/camel-jacksonxml/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jacksonxml</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jasypt/pom.xml
+++ b/components/camel-jasypt/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jasypt</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-javascript/pom.xml
+++ b/components/camel-javascript/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-javascript</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jaxb/pom.xml
+++ b/components/camel-jaxb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jaxb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jcache/pom.xml
+++ b/components/camel-jcache/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <camel.osgi.export>
             !org.apache.camel.util*,
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jcache</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-util</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- osgi support -->

--- a/components/camel-jcr/pom.xml
+++ b/components/camel-jcr/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jcr</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jdbc/pom.xml
+++ b/components/camel-jdbc/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jdbc</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jetty-common/pom.xml
+++ b/components/camel-jetty-common/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jetty-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jetty/pom.xml
+++ b/components/camel-jetty/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jetty</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jfr/pom.xml
+++ b/components/camel-jfr/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             !jdk.jfr,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jfr</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jgroups-raft/pom.xml
+++ b/components/camel-jgroups-raft/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jgroups-raft</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jgroups/pom.xml
+++ b/components/camel-jgroups/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jgroups</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jira/pom.xml
+++ b/components/camel-jira/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             com.google.common*;version="[33,34)",
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jira</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jms/pom.xml
+++ b/components/camel-jms/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             !org.apache.camel.component.cron*,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jms</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jmx/pom.xml
+++ b/components/camel-jmx/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jmx</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jolt/pom.xml
+++ b/components/camel-jolt/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jolt</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jooq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-joor/pom.xml
+++ b/components/camel-joor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-joor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jpa</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jq/pom.xml
+++ b/components/camel-jq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jsch/pom.xml
+++ b/components/camel-jsch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jslt/pom.xml
+++ b/components/camel-jslt/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jslt</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-json-patch/pom.xml
+++ b/components/camel-json-patch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-json-patch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-json-validator/pom.xml
+++ b/components/camel-json-validator/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-json-validator</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jsonapi/pom.xml
+++ b/components/camel-jsonapi/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsonapi</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jsonata/pom.xml
+++ b/components/camel-jsonata/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsonata</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jsonb/pom.xml
+++ b/components/camel-jsonb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsonb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jsonpath/pom.xml
+++ b/components/camel-jsonpath/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsonpath</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jt400/pom.xml
+++ b/components/camel-jt400/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jt400</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jta/pom.xml
+++ b/components/camel-jta/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jta</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jte/pom.xml
+++ b/components/camel-jte/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jte</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kafka</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-kamelet/pom.xml
+++ b/components/camel-kamelet/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kamelet</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-kubernetes/pom.xml
+++ b/components/camel-kubernetes/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kubernetes</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-kudu/pom.xml
+++ b/components/camel-kudu/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kudu</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-language/pom.xml
+++ b/components/camel-language/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-language</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ldap/pom.xml
+++ b/components/camel-ldap/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ldap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ldif/pom.xml
+++ b/components/camel-ldif/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ldif</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-leveldb/pom.xml
+++ b/components/camel-leveldb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-leveldb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-log/pom.xml
+++ b/components/camel-log/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-log</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-lra/pom.xml
+++ b/components/camel-lra/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-lra</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-lucene/pom.xml
+++ b/components/camel-lucene/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-lucene</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-lumberjack/pom.xml
+++ b/components/camel-lumberjack/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-lumberjack</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-lzf/pom.xml
+++ b/components/camel-lzf/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-lzf</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mail-microsoft-oauth/pom.xml
+++ b/components/camel-mail-microsoft-oauth/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mail-microsoft-oauth</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             jakarta.mail*;version="[2,3)",
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mail</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mapstruct/pom.xml
+++ b/components/camel-mapstruct/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mapstruct</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-master/pom.xml
+++ b/components/camel-master/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-master</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-metrics/pom.xml
+++ b/components/camel-metrics/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-metrics</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-micrometer-prometheus/pom.xml
+++ b/components/camel-micrometer-prometheus/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-micrometer-prometheus</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-micrometer</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mina/pom.xml
+++ b/components/camel-mina/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mina</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-minio/pom.xml
+++ b/components/camel-minio/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-minio</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mllp/pom.xml
+++ b/components/camel-mllp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mllp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mock/pom.xml
+++ b/components/camel-mock/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mongodb-gridfs/pom.xml
+++ b/components/camel-mongodb-gridfs/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mongodb-gridfs</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mongodb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mustache/pom.xml
+++ b/components/camel-mustache/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mustache</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mvel/pom.xml
+++ b/components/camel-mvel/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mvel</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mybatis/pom.xml
+++ b/components/camel-mybatis/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mybatis</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-nats/pom.xml
+++ b/components/camel-nats/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-nats</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-netty-http/pom.xml
+++ b/components/camel-netty-http/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-netty-http</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-netty/pom.xml
+++ b/components/camel-netty/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             io.netty.channel.kqueue;resolution:=optional,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-netty</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-nitrite/pom.xml
+++ b/components/camel-nitrite/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-nitrite</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-oaipmh/pom.xml
+++ b/components/camel-oaipmh/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-oaipmh</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-observation/pom.xml
+++ b/components/camel-observation/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-observation</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ognl/pom.xml
+++ b/components/camel-ognl/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ognl</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-olingo2/pom.xml
+++ b/components/camel-olingo2/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-olingo2</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-olingo2-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-olingo4/pom.xml
+++ b/components/camel-olingo4/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-olingo4</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-olingo4-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-openapi-java/pom.xml
+++ b/components/camel-openapi-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-openapi-java</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-opensearch/pom.xml
+++ b/components/camel-opensearch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-opensearch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-openstack/pom.xml
+++ b/components/camel-openstack/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-openstack</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-opentelemetry/pom.xml
+++ b/components/camel-opentelemetry/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-opentelemetry</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-optaplanner</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-paho-mqtt5/pom.xml
+++ b/components/camel-paho-mqtt5/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-paho-mqtt5</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-paho/pom.xml
+++ b/components/camel-paho/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-paho</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-parquet-avro/pom.xml
+++ b/components/camel-parquet-avro/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-parquet-avro</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-pdf/pom.xml
+++ b/components/camel-pdf/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-pdf</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-pg-replication-slot/pom.xml
+++ b/components/camel-pg-replication-slot/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-pg-replication-slot</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-pgevent/pom.xml
+++ b/components/camel-pgevent/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-pgevent</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-platform-http-main/pom.xml
+++ b/components/camel-platform-http-main/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-platform-http-main</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-platform-http-vertx/pom.xml
+++ b/components/camel-platform-http-vertx/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-platform-http-vertx</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-platform-http/pom.xml
+++ b/components/camel-platform-http/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-platform-http</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-plc4x/pom.xml
+++ b/components/camel-plc4x/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-plc4x</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-printer/pom.xml
+++ b/components/camel-printer/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-printer</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-protobuf/pom.xml
+++ b/components/camel-protobuf/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-protobuf</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-pubnub/pom.xml
+++ b/components/camel-pubnub/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-pubnub</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-pulsar/pom.xml
+++ b/components/camel-pulsar/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-pulsar</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-python/pom.xml
+++ b/components/camel-python/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-python</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-quartz/pom.xml
+++ b/components/camel-quartz/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-quartz</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-quickfix/pom.xml
+++ b/components/camel-quickfix/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-quickfix</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-reactive-executor-tomcat/pom.xml
+++ b/components/camel-reactive-executor-tomcat/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-reactive-executor-tomcat</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-reactive-executor-vertx/pom.xml
+++ b/components/camel-reactive-executor-vertx/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-reactive-executor-vertx</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-reactive-streams/pom.xml
+++ b/components/camel-reactive-streams/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-reactive-streams</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-reactor/pom.xml
+++ b/components/camel-reactor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-reactor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-redis/pom.xml
+++ b/components/camel-redis/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-redis</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ref/pom.xml
+++ b/components/camel-ref/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ref</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-resilience4j/pom.xml
+++ b/components/camel-resilience4j/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-resilience4j</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-resourceresolver-github/pom.xml
+++ b/components/camel-resourceresolver-github/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-resourceresolver-github</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-rest-openapi</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-rest/pom.xml
+++ b/components/camel-rest/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-rest</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-robotframework/pom.xml
+++ b/components/camel-robotframework/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-robotframework</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-rocketmq/pom.xml
+++ b/components/camel-rocketmq/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-rocketmq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-rss/pom.xml
+++ b/components/camel-rss/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-rss</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-rxjava/pom.xml
+++ b/components/camel-rxjava/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-rxjava</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-saga/pom.xml
+++ b/components/camel-saga/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-saga</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-salesforce/pom.xml
+++ b/components/camel-salesforce/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             !com.salesforce.eventbus.protobuf*,
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sap-netweaver/pom.xml
+++ b/components/camel-sap-netweaver/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sap-netweaver</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-saxon/pom.xml
+++ b/components/camel-saxon/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-saxon</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-scheduler/pom.xml
+++ b/components/camel-scheduler/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-scheduler</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-schematron/pom.xml
+++ b/components/camel-schematron/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-schematron</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-seda/pom.xml
+++ b/components/camel-seda/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-seda</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-service/pom.xml
+++ b/components/camel-service/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-service</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-servicenow/pom.xml
+++ b/components/camel-servicenow/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-servicenow</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-servlet/pom.xml
+++ b/components/camel-servlet/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-servlet</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-shiro/pom.xml
+++ b/components/camel-shiro/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-shiro</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sjms/pom.xml
+++ b/components/camel-sjms/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sjms</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sjms2/pom.xml
+++ b/components/camel-sjms2/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sjms2</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cloudevents*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-slack</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-smb/pom.xml
+++ b/components/camel-smb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-smb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-smpp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-snakeyaml/pom.xml
+++ b/components/camel-snakeyaml/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-snakeyaml</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-snmp/pom.xml
+++ b/components/camel-snmp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-snmp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version},
+            org.apache.camel*;version=${camel-version},
             org.w3._2003._05.soap_envelope,
             org.xmlsoap.schemas.soap.envelope
         </camel.osgi.export>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-soap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-splunk-hec/pom.xml
+++ b/components/camel-splunk-hec/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-splunk-hec</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-splunk/pom.xml
+++ b/components/camel-splunk/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-splunk</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-batch/pom.xml
+++ b/components/camel-spring-batch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-batch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-jdbc/pom.xml
+++ b/components/camel-spring-jdbc/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-jdbc</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-ldap/pom.xml
+++ b/components/camel-spring-ldap/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-ldap</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-main/pom.xml
+++ b/components/camel-spring-main/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-main</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-rabbitmq/pom.xml
+++ b/components/camel-spring-rabbitmq/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version},
-            org.springframework.amqp*;version=${spring.amqp.version}
+            org.apache.camel*;version=${camel-version},
+            org.springframework.amqp*;version=${spring-amqp-version}
         </camel.osgi.export>
         <camel.osgi.import>
             !org.springframework.amqp*,
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-rabbitmq</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit</artifactId>
-            <version>${spring.amqp.version}</version>
+            <version>${spring-amqp-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.amqp</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-amqp</artifactId>
-            <version>${spring.amqp.version}</version>
+            <version>${spring-amqp-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.amqp</groupId>

--- a/components/camel-spring-redis/pom.xml
+++ b/components/camel-spring-redis/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-redis</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-security/pom.xml
+++ b/components/camel-spring-security/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-security</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-ws/pom.xml
+++ b/components/camel-spring-ws/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-ws</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring-xml/pom.xml
+++ b/components/camel-spring-xml/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-xml</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-spring/pom.xml
+++ b/components/camel-spring/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
-        <camel.osgi.camel.import>
-            org.apache.camel.component.cron*;${camel.osgi.import.camel.version};resolution:=optional,
-            org.apache.camel*;${camel.osgi.import.camel.version},
-        </camel.osgi.camel.import>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cron*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
         <camel.osgi.import>
             *
         </camel.osgi.import>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sql/pom.xml
+++ b/components/camel-sql/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sql</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-ssh/pom.xml
+++ b/components/camel-ssh/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ssh</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stax</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stitch/pom.xml
+++ b/components/camel-stitch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stitch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stomp/pom.xml
+++ b/components/camel-stomp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stomp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stream/pom.xml
+++ b/components/camel-stream/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stream</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stringtemplate/pom.xml
+++ b/components/camel-stringtemplate/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stringtemplate</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-stub/pom.xml
+++ b/components/camel-stub/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-stub</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-swift</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-syslog/pom.xml
+++ b/components/camel-syslog/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-syslog</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-tarfile/pom.xml
+++ b/components/camel-tarfile/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-tarfile</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-telegram/pom.xml
+++ b/components/camel-telegram/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-telegram</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-test-spring/pom.xml
+++ b/components/camel-test-spring/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-test/pom.xml
+++ b/components/camel-test/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-junit5</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-threadpoolfactory-vertx/pom.xml
+++ b/components/camel-threadpoolfactory-vertx/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-threadpoolfactory-vertx</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-thrift/pom.xml
+++ b/components/camel-thrift/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-thrift</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-thymeleaf/pom.xml
+++ b/components/camel-thymeleaf/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-thymeleaf</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-tika/pom.xml
+++ b/components/camel-tika/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-tika</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-timer/pom.xml
+++ b/components/camel-timer/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-timer</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-tracing/pom.xml
+++ b/components/camel-tracing/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-tracing</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-twilio/pom.xml
+++ b/components/camel-twilio/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-twilio</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-twitter/pom.xml
+++ b/components/camel-twitter/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-twitter</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-undertow-spring-security/pom.xml
+++ b/components/camel-undertow-spring-security/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-undertow-spring-security</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-undertow</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-univocity-parsers/pom.xml
+++ b/components/camel-univocity-parsers/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-univocity-parsers</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-validator/pom.xml
+++ b/components/camel-validator/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-validator</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-velocity/pom.xml
+++ b/components/camel-velocity/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-velocity</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-vertx/camel-vertx-common/pom.xml
+++ b/components/camel-vertx/camel-vertx-common/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-vertx-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-vertx/camel-vertx-http/pom.xml
+++ b/components/camel-vertx/camel-vertx-http/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-vertx-http</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-vertx/camel-vertx-websocket/pom.xml
+++ b/components/camel-vertx/camel-vertx-websocket/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-vertx-websocket</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-vertx/camel-vertx/pom.xml
+++ b/components/camel-vertx/camel-vertx/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-vertx</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-vm/pom.xml
+++ b/components/camel-vm/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel.karaf.component.vm.*;version=${camel.version}
+            org.apache.camel.karaf.component.vm.*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-seda</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-package-maven-plugin</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-version}</version>
                 <configuration>
                     <!-- set to true to make build fail fast if missing documentation in docs file -->
                     <failFast>false</failFast>
@@ -79,7 +79,7 @@
                     <dependency>
                         <groupId>org.apache.camel</groupId>
                         <artifactId>camel-core-model</artifactId>
-                        <version>${camel.version}</version>
+                        <version>${camel-version}</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>

--- a/components/camel-wal/pom.xml
+++ b/components/camel-wal/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-wal</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-weather/pom.xml
+++ b/components/camel-weather/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-weather</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-web3j/pom.xml
+++ b/components/camel-web3j/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-web3j</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-webhook/pom.xml
+++ b/components/camel-webhook/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-webhook</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-whatsapp/pom.xml
+++ b/components/camel-whatsapp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-whatsapp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-wordpress/pom.xml
+++ b/components/camel-wordpress/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-wordpress</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-workday/pom.xml
+++ b/components/camel-workday/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-workday</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xchange/pom.xml
+++ b/components/camel-xchange/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xchange</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xj/pom.xml
+++ b/components/camel-xj/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xj</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xmlsecurity/pom.xml
+++ b/components/camel-xmlsecurity/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xmlsecurity</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xmpp/pom.xml
+++ b/components/camel-xmpp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xmpp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xpath/pom.xml
+++ b/components/camel-xpath/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xpath</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xslt-saxon/pom.xml
+++ b/components/camel-xslt-saxon/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xslt-saxon</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-xslt/pom.xml
+++ b/components/camel-xslt/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xslt</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-yaml-dsl/pom.xml
+++ b/components/camel-yaml-dsl/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-yaml-dsl-common</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-yaml-dsl</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-yaml-dsl-deserializers</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-dsl-support</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zeebe</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zendesk/pom.xml
+++ b/components/camel-zendesk/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zendesk</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zip-deflater/pom.xml
+++ b/components/camel-zip-deflater/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zip-deflater</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zipfile/pom.xml
+++ b/components/camel-zipfile/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zipfile</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zookeeper-master/pom.xml
+++ b/components/camel-zookeeper-master/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zookeeper-master</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-zookeeper/pom.xml
+++ b/components/camel-zookeeper/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zookeeper</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-api/pom.xml
+++ b/core/camel-api/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-base-engine/pom.xml
+++ b/core/camel-base-engine/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-base-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-base/pom.xml
+++ b/core/camel-base/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-base</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-cloud/pom.xml
+++ b/core/camel-cloud/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cloud</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-cluster/pom.xml
+++ b/core/camel-cluster/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel.impl.cluster*;version=${camel.version}
+            org.apache.camel.impl.cluster*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cluster</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-console/pom.xml
+++ b/core/camel-console/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-console</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-catalog/pom.xml
+++ b/core/camel-core-catalog/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-catalog</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-engine/pom.xml
+++ b/core/camel-core-engine/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-languages/pom.xml
+++ b/core/camel-core-languages/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-languages</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-model/pom.xml
+++ b/core/camel-core-model/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-model</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,11 +66,11 @@
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.apache.camel.karaf.core*;version=${camel.version}
+                            org.apache.camel.karaf.core*;version=${camel-version}
                         </Export-Package>
                         <Import-Package>
                             org.osgi.service.event;resolution:=optional,
-                            org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.apache.camel*;${camel-osgi-import-camel-version},
                             *
                         </Import-Package>
                         <Provide-Capability>

--- a/core/camel-core-processor/pom.xml
+++ b/core/camel-core-processor/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-processor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-reifier/pom.xml
+++ b/core/camel-core-reifier/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-reifier</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-core-xml/pom.xml
+++ b/core/camel-core-xml/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-xml</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-health/pom.xml
+++ b/core/camel-health/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-health</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-main/pom.xml
+++ b/core/camel-main/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-main</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-management-api/pom.xml
+++ b/core/camel-management-api/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-management-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-management/pom.xml
+++ b/core/camel-management/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-management</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-support/pom.xml
+++ b/core/camel-support/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-support</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-tooling-model/pom.xml
+++ b/core/camel-tooling-model/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-tooling-model</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-util-json/pom.xml
+++ b/core/camel-util-json/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-util-json</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-util/pom.xml
+++ b/core/camel-util/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-util</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-xml-io-util/pom.xml
+++ b/core/camel-xml-io-util/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-io-util</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-xml-jaxb/pom.xml
+++ b/core/camel-xml-jaxb/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxb</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/core/camel-xml-jaxp/pom.xml
+++ b/core/camel-xml-jaxp/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel.version}
+            org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxp</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xml-jaxp-util</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
-            <version>${karaf.version}</version>
+            <version>${karaf-version}</version>
             <type>kar</type>
             <scope>provided</scope>
         </dependency>
@@ -87,15 +87,15 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <configuration>
                     <descriptors>
                         <descriptor>file:${project.build.directory}/feature/camel-features.xml</descriptor>
-                        <descriptor>mvn:org.apache.karaf.features/specs/${karaf.version}/xml/features</descriptor>
-                        <descriptor>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</descriptor>
+                        <descriptor>mvn:org.apache.karaf.features/specs/${karaf-version}/xml/features</descriptor>
+                        <descriptor>mvn:org.apache.karaf.features/spring/${karaf-version}/xml/features</descriptor>
                     </descriptors>
                     <distribution>org.apache.karaf.features:framework</distribution>
-                    <javase>${jdk.version}</javase>
+                    <javase>${jdk-version}</javase>
                     <framework>
                         <feature>framework</feature>
                     </framework>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -23,13 +23,13 @@
     <feature name="jakarta-activation" version="${jakarta-activation-version}">
         <bundle dependency="true">mvn:jakarta.activation/jakarta.activation-api/${jakarta-activation-version}</bundle>
     </feature>
-    <feature name="jakarta-annotation" version="2.1.1">
-        <bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/2.1.1</bundle>
+    <feature name="jakarta-annotation" version="${jakarta-annotation2-api-version}">
+        <bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${jakarta-annotation2-api-version}</bundle>
     </feature>
 
-    <feature name="jakarta-xml-bind" version="3.0.1">
+    <feature name="jakarta-xml-bind" version="${jakarta-xml-bind3-api-version}">
         <feature version="[2,3)">jakarta-activation</feature>
-        <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/3.0.1</bundle>
+        <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/${jakarta-xml-bind3-api-version}</bundle>
     </feature>
 
     <feature name="jakarta-xml-bind" version="${jakarta-xml-bind-api-version}">
@@ -41,23 +41,23 @@
         <bundle dependency="true">mvn:jakarta.xml.ws/jakarta.xml.ws-api/${jakarta-xml-ws-api-version}</bundle>
     </feature>
 
-    <feature name="jakarta-ws-rs" version="3.1.0">
-        <bundle dependency="true">mvn:jakarta.ws.rs/jakarta.ws.rs-api/3.1.0</bundle>
+    <feature name="jakarta-ws-rs" version="${jakarta-ws-rs-api-version}">
+        <bundle dependency="true">mvn:jakarta.ws.rs/jakarta.ws.rs-api/${jakarta-ws-rs-api-version}</bundle>
     </feature>
 
-    <feature name="jakarta-validation" version="3.0.2">
-        <bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/3.0.2</bundle>
+    <feature name="jakarta-validation" version="${jakarta-validation-api-version}">
+        <bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/${jakarta-validation-api-version}</bundle>
     </feature>
 
     <feature name="jakarta-jws" version="${jakarta-jws-api-version}">
         <bundle dependency="true">mvn:jakarta.jws/jakarta.jws-api/${jakarta-jws-api-version}</bundle>
     </feature>
 
-    <feature name="jaxb-runtime" version="3.0.2">
+    <feature name="jaxb-runtime" version="${jaxb3-core-version}">
         <feature version="[3,4)">jakarta-xml-bind</feature>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/3.0.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/3.0.2</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-osgi/3.0.2</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/${jaxb3-core-version}</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/${jaxb3-impl-version}</bundle>
+        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-osgi/${jaxb3-osgi-version}</bundle>
     </feature>
 
     <feature name="jaxb-runtime" version="${jaxb-core-version}">
@@ -67,13 +67,13 @@
         <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-osgi/${jaxb-osgi-version}</bundle>
     </feature>
 
-    <feature name="activation-runtime" version="2.0.1">
+    <feature name="activation-runtime" version="${angus-activation-version}">
         <feature version="[2.1,3)">jakarta-activation</feature>
-        <bundle dependency="true">mvn:org.eclipse.angus/angus-activation/2.0.1</bundle>
+        <bundle dependency="true">mvn:org.eclipse.angus/angus-activation/${angus-activation-version}</bundle>
     </feature>
 
-    <feature name="jakarta-servlet" version="5.0.0">
-        <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/5.0.0</bundle>
+    <feature name="jakarta-servlet" version="${jakarta-servlet5-api-version}">
+        <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/${jakarta-servlet5-api-version}</bundle>
     </feature>
 
     <feature name="jakarta-servlet" version="${jakarta-servlet-api-version}">
@@ -96,17 +96,17 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
     </feature>
 
-    <feature name="jetty" version="11.0.18">
+    <feature name="jetty" version="${jetty11-version}">
         <feature version="[5,6)">jakarta-servlet</feature>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-server/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-security/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-hpack/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-common/11.0.18</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-server/11.0.18</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-server/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-security/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-hpack/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-common/${jetty11-version}</bundle>
+        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-server/${jetty11-version}</bundle>
     </feature>
 
     <feature name="jetty" version="${jetty-version}">
@@ -124,9 +124,9 @@
         <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-server/${jetty-version}</bundle>
     </feature>
 
-    <feature name="http-client" version="4.5.14">
-        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
-        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+    <feature name="http-client" version="${httpclient4-version}">
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
     </feature>
 
     <feature name="http-client" version="${httpclient-version}">
@@ -145,16 +145,16 @@
     </feature>
 
     <feature name='xml-specs-api' version='${servicemix-specs-version}' start-level='10'>
-        <feature version="[2.1,3)">jakarta-activation</feature>
-        <feature>jakarta-annotation</feature>
-        <feature>jakarta-xml-ws</feature>
-        <feature>jakarta-ws-rs</feature>
-        <feature>jakarta-soap</feature>
-        <feature>jakarta-xml-bind</feature>
-        <feature>jaxb-runtime</feature>
-        <feature>activation-runtime</feature>
-        <bundle>mvn:org.codehaus.woodstox/stax2-api/4.2.1</bundle>
-        <bundle>mvn:com.fasterxml.woodstox/woodstox-core/6.5.1</bundle>
+        <feature version="${camel-osgi-jakarta-activation-version}">jakarta-activation</feature>
+        <feature version="${camel-osgi-jakarta-annotation-version}">jakarta-annotation</feature>
+        <feature version="${camel-osgi-jakarta-xml-ws-version}">jakarta-xml-ws</feature>
+        <feature version="${camel-osgi-jakarta-ws-rs-version}">jakarta-ws-rs</feature>
+        <feature version="${camel-osgi-jakarta-soap-version}">jakarta-soap</feature>
+        <feature version="${camel-osgi-jakarta-bind-version}">jakarta-xml-bind</feature>
+        <feature version="${camel-osgi-jakarta-bind-version}">jaxb-runtime</feature>
+        <feature version="${camel-osgi-jakarta-activation-runtime-version}">activation-runtime</feature>
+        <bundle>mvn:org.codehaus.woodstox/stax2-api/${auto-detect-version}</bundle>
+        <bundle>mvn:com.fasterxml.woodstox/woodstox-core/${woodstox-core-version}</bundle>
     </feature>
 
     <feature name="awssdk" version="${aws-java-sdk2-version}" start-level="50">
@@ -181,43 +181,43 @@
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/third-party-jackson-core/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
     </feature>
-    <feature name="azure" version="1.48.0" start-level="50">
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/1.48.0</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-identity/1.12.0</bundle>
+    <feature name="azure" version="${azure-core-version}" start-level="50">
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/${azure-core-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-identity/${azure-identity-version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
-        <bundle dependency='true'>mvn:io.projectreactor/reactor-core/3.4.36</bundle>
+        <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${auto-detect-version}</bundle>
     </feature>
-    <feature name="azure-storage" version="1.48.0" start-level="50">
-        <feature version='[1.48,2)'>azure</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-common/12.24.4</bundle>
+    <feature name="azure-storage" version="${azure-core-version}" start-level="50">
+        <feature version='[${azure-core-version},2)'>azure</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-common/${azure-storage-common-version}</bundle>
     </feature>
-    <feature name="azure-eventhubs" version="1.48.0" start-level="50">
-        <feature version='[1.48,2)'>azure-storage</feature>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/2.9.3</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs/5.18.3</bundle>
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs-checkpointstore-blob/1.19.3</bundle>
+    <feature name="azure-eventhubs" version="${azure-core-version}" start-level="50">
+        <feature version='[${azure-core-version},2)'>azure-storage</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs/${azure-messaging-eventhubs-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-eventhubs-checkpointstore-blob/${azure-messaging-eventhubs-checkpointstore-blob-version}</bundle>
     </feature>
     <feature name="guava" version="${guava-version}">
         <bundle dependency='true'>mvn:com.google.guava/guava/${guava-version}</bundle>
-        <bundle dependency='true'>mvn:com.google.guava/failureaccess/1.0.2</bundle>
+        <bundle dependency='true'>mvn:com.google.guava/failureaccess/${auto-detect-version}</bundle>
     </feature>
 
     <!--For use where version 33 is not allowed -->
-    <feature name="guava" version="32.1.3">
-        <bundle dependency='true'>mvn:com.google.guava/guava/32.1.3-jre</bundle>
-        <bundle dependency='true'>mvn:com.google.guava/failureaccess/1.0.2</bundle>
+    <feature name="guava" version="${guava32-version}">
+        <bundle dependency='true'>mvn:com.google.guava/guava/${guava32-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.guava/failureaccess/${auto-detect-version}</bundle>
     </feature>
 
     <!-- Apache Camel core features -->
 
     <feature name="camel" version="${project.version}" start-level="50">
         <feature prerequisite="true">wrap</feature>
-        <feature version="${camel.osgi.version.range}">camel-core</feature>
-        <feature version="${camel.osgi.version.range}">camel-blueprint</feature>
+        <feature version="${camel-osgi-version-range}">camel-core</feature>
+        <feature version="${camel-osgi-version-range}">camel-blueprint</feature>
     </feature>
 
     <feature name="camel-core" version="${project.version}" start-level="50">
-        <feature>xml-specs-api</feature>
+        <feature version="[${servicemix-specs-version},11)">xml-specs-api</feature>
         <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-api/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-management-api/${project.version}</bundle>
@@ -277,15 +277,15 @@
     </feature>
 
     <feature name="camel-blueprint" version="${project.version}" start-level="50">
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature>aries-blueprint</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-core-xml/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-blueprint/${project.version}</bundle>
     </feature>
     <feature name='camel-spring' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-tx</feature>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-tx</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-core-xml/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-xml/${project.version}</bundle>
@@ -294,14 +294,14 @@
     <!-- the following features are sorted A..Z -->
 
     <feature name='camel-activemq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jms</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jms</feature>
         <bundle dependency='true'>mvn:org.apache.activemq/activemq-client/${activemq-version}</bundle>
         <bundle dependency='true'>mvn:org.fusesource.hawtbuf/hawtbuf/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-activemq/${project.version}</bundle>
     </feature>
 
     <feature name='camel-amqp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jms</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jms</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>mvn:org.apache.qpid/qpid-jms-client/${qpid-jms-client-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.qpid/proton-j/${qpid-proton-j-version}</bundle>
@@ -311,13 +311,13 @@
     </feature>
 
     <feature name='camel-arangodb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-arangodb/${project.version}</bundle>
     </feature>
     <feature name='camel-as2' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[5,6)">http-client</feature>
-        <feature version="${bouncycastle-version}">bouncycastle</feature>
+        <feature version="[${bouncycastle-version},2)">bouncycastle</feature>
         <!-- Wrap protocol used to export a private package that is used by camel-as2  -->
         <bundle dependency='true'>wrap:mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle-version}$overwrite=merge&amp;Export-Package=org.bouncycastle.*;version=${bouncycastle-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity-version}</bundle>
@@ -325,87 +325,87 @@
         <bundle>mvn:org.apache.camel.karaf/camel-as2/${project.version}</bundle>
     </feature>
     <feature name='camel-asn1' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.beanit/asn1bean/${asn1bean-version}</bundle>
         <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-asn1/${project.version}</bundle>
     </feature>
     <feature name='camel-asterisk' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.asteriskjava/asterisk-java/${asterisk-java-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-asterisk/${project.version}</bundle>
     </feature>
     <feature name='camel-atmosphere-websocket' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-servlet</feature>
+        <feature version='${camel-osgi-version-range}'>camel-servlet</feature>
         <!-- Wrap protocol used to work around the wrong version range used for the servlet API [2.5,4)  -->
         <bundle dependency="true">wrap:mvn:org.atmosphere/atmosphere-runtime/${atmosphere-version}$overwrite=merge&amp;Import-Package=jakarta.servlet;version:="[6,7)",*;resolution:=optional</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-atmosphere-websocket/${project.version}</bundle>
     </feature>
     <feature name='camel-atom' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">wrap:mvn:com.apptasticsoftware/rssreader/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-atom/${project.version}</bundle>
     </feature>
     <feature name='camel-avro' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.avro/avro/${avro-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-avro/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-athena' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/athena/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-athena/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-cw' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudwatch/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-cw/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-ddb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/dynamodb/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-ddb/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-ec2' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ec2/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-ec2/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-ecs' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ecs/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-ecs/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-eks' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/eks/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-eks/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-eventbridge' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/eventbridge/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-eventbridge/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-iam' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/iam/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-iam/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-kinesis' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency="true">wrap:mvn:software.amazon.awssdk/netty-nio-client/${aws-java-sdk2-version}</bundle>
         <bundle dependency="true">wrap:mvn:software.amazon.awssdk/firehose/${aws-java-sdk2-version}</bundle>
@@ -413,57 +413,57 @@
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-kinesis/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-kms' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/kms/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-kms/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-lambda' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/lambda/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-lambda/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-mq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/mq/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-mq/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-msk' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/kafka/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-msk/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-redshift' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/redshiftdata/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-redshift/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-s3' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/s3/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-s3/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-ses' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency="true">mvn:jakarta.mail/jakarta.mail-api/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ses/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-ses/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-sns' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sns/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-sns/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-sqs' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sqs/${aws-java-sdk2-version}</bundle>
@@ -471,121 +471,121 @@
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-sqs/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-step-functions' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sfn/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-step-functions/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-sts' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sts/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-sts/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-timestream' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/timestreamquery/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/timestreamwrite/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-timestream/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-translate' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/translate/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-translate/${project.version}</bundle>
     </feature>
     <feature name='camel-aws-cloudtrail' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws-cloudtrail/${project.version}</bundle>
     </feature>
     <feature name='camel-aws-config' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/config/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws-config/${project.version}</bundle>
     </feature>
     <feature name='camel-aws-secrets-manager' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/secretsmanager/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws-secrets-manager/${project.version}</bundle>
     </feature>
     <feature name='camel-aws-xray' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-core/${aws-xray-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws-xray/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-cosmosdb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
-        <feature version='[1.48,2)'>azure</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <feature version='[${azure-core-version},2)'>azure</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-cosmos/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-cosmosdb/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-eventhubs' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure-eventhubs</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure-eventhubs</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-eventhubs/${project.version}</bundle>
     </feature>  
     <feature name='camel-azure-files' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-ftp</feature>
-        <feature version='[1.48,2)'>azure-storage</feature>
+        <feature version='${camel-osgi-version-range}'>camel-ftp</feature>
+        <feature version='[${azure-core-version},2)'>azure-storage</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-share/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-files/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-key-vault' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
-        <feature version='[1.48,2)'>azure-eventhubs</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <feature version='[${azure-core-version},2)'>azure-eventhubs</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-security-keyvault-secrets/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-key-vault/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-schema-registry' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-schema-registry/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-servicebus' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-core-amqp/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-messaging-servicebus/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-servicebus/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-blob' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure-storage</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure-storage</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob-changefeed/${azure-storage-blob-changefeed-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-blob/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-datalake' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure-storage</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure-storage</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-file-datalake/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-datalake/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-queue' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='[1.48,2)'>azure-storage</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${azure-core-version},2)'>azure-storage</feature>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-queue/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-queue/${project.version}</bundle>
     </feature>
     <feature name='camel-base64' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-base64/${project.version}</bundle>
     </feature>
     <feature name='camel-bean-validator' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature>jakarta-validation</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="[3,4)">jakarta-validation</feature>
         <bundle>mvn:org.hibernate.validator/hibernate-validator/${hibernate-validator-version}</bundle>
         <bundle>mvn:org.jboss.logging/jboss-logging/${jboss-logging-version}</bundle>
         <bundle>mvn:com.fasterxml/classmate/${auto-detect-version}</bundle>
@@ -593,19 +593,19 @@
         <bundle>mvn:org.apache.camel.karaf/camel-bean-validator/${project.version}</bundle>
     </feature>
     <feature name='camel-barcode' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.google.zxing/core/${zxing-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.zxing/javase/${zxing-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-barcode/${project.version}</bundle>
     </feature>
     <feature name='camel-bindy' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.ibm.icu/icu4j/${icu4j-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-bindy/${project.version}</bundle>
     </feature>
     <feature name='camel-bonita' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[5,6)">jakarta-servlet</feature>
         <feature version="[3,4)">jaxb-runtime</feature>
         <bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${auto-detect-version}</bundle>
@@ -618,31 +618,31 @@
         <bundle>mvn:org.apache.camel.karaf/camel-bonita/${project.version}</bundle>
     </feature>
     <feature name='camel-box' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[12,13)">jetty</feature>
-        <feature version='${bouncycastle-version}'>bouncycastle</feature>
+        <feature version='[${bouncycastle-version},2)'>bouncycastle</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle dependency='true'>mvn:org.jsoup/jsoup/${jsoup-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.box/box-java-sdk/${box-java-sdk-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-box/${project.version}</bundle>
     </feature>
     <feature name='camel-braintree' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jr/jackson-jr-objects/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-csv/${commons-csv-version}</bundle>
         <bundle dependency='true'>mvn:com.braintreepayments.gateway/braintree-java/${braintree-gateway-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-braintree/${project.version}</bundle>
     </feature>
     <feature name='camel-caffeine' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeine-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-caffeine/${project.version}</bundle>
     </feature>
     <feature name='camel-cassandraql' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency="true">mvn:com.datastax.oss/java-driver-core/${cassandra-driver-version}</bundle>
         <bundle dependency='true'>mvn:com.datastax.oss/java-driver-query-builder/${cassandra-driver-version}</bundle>
@@ -654,37 +654,37 @@
         <bundle>mvn:org.apache.camel.karaf/camel-cassandraql/${project.version}</bundle>
     </feature>
     <feature name='camel-cbor' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/${jackson2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-cbor/${project.version}</bundle>
     </feature>
     <feature name='camel-chatscript' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-chatscript/${project.version}</bundle>
     </feature>
     <feature name='camel-chunk' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.x5dev/chunk-templates/${chunk-templates-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-chunk/${project.version}</bundle>
     </feature>
     <feature name='camel-cloudevents' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-cloudevents/${project.version}</bundle>
     </feature>
     <feature name='camel-cm-sms' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature>jakarta-validation</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="[3,4)">jakarta-validation</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle dependency='true'>mvn:com.googlecode.libphonenumber/libphonenumber/${libphonenumber-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-cm-sms/${project.version}</bundle>
     </feature>
     <feature name='camel-coap' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-netty</feature>
-        <feature version='${bouncycastle-version}'>bouncycastle</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-netty</feature>
+        <feature version='[${bouncycastle-version},2)'>bouncycastle</feature>
         <bundle dependency='true'>mvn:org.eclipse.californium/californium-core/${californium-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.eclipse.californium/element-connector/${californium-version}$overwrite=merge&amp;Import-Package=net.i2p.crypto.eddsa;resolution:=optional</bundle>
         <bundle dependency='true'>mvn:org.eclipse.californium/element-connector-tcp-netty/${californium-version}</bundle>
@@ -692,7 +692,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-coap/${project.version}</bundle>
     </feature>
     <feature name='camel-cometd' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <feature version="${jetty-version}">jetty</feature>
         <bundle dependency='true'>mvn:org.eclipse.jetty.ee10/jetty-ee10-servlet/${jetty-version}</bundle>
@@ -706,12 +706,12 @@
         <bundle>mvn:org.apache.camel.karaf/camel-cometd/${project.version}</bundle>
     </feature>
     <feature name='camel-consul' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.kiwiproject/consul-client/${consul-client-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-consul/${project.version}</bundle>
     </feature>
     <feature name='camel-couchbase' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.couchbase.client/core-io/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.couchbase.client/java-client/${couchbase-client-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
@@ -719,41 +719,41 @@
         <bundle>mvn:org.apache.camel.karaf/camel-couchbase/${project.version}</bundle>
     </feature>
     <feature name='camel-couchdb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>mvn:com.google.code.gson/gson/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.lightcouch/lightcouch/${lightcouch-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-couchdb/${project.version}</bundle>
     </feature>
     <feature name="camel-cron" version="${project.version}" start-level="50">
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-cron/${project.version}</bundle>
     </feature>
     <feature name='camel-crypto' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${bouncycastle-version}'>bouncycastle</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[${bouncycastle-version},2)'>bouncycastle</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-crypto/${project.version}</bundle>
     </feature>
     <feature name='camel-csimple-joor' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <!-- wrap protocol needed because joor has a Require-Capability: osgi.ee;filter:="(osgi.ee=UNKNOWN) in its manifest.
          The wrap does not support & , so it's not possible to add version to the filter -->
         <bundle dependency='true'>wrap:mvn:org.jooq/joor/${joor-version}$overwrite=merge&amp;Require-Capability=osgi.ee;filter:="(osgi.ee=JavaSE)"</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-csimple-joor/${project.version}</bundle>
     </feature>
     <feature name='camel-csv' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-csv/${commons-csv-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-csv/${project.version}</bundle>
     </feature>
     <feature name='camel-cxf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-blueprint</feature>
-        <feature version='${camel.osgi.version.range}'>camel-spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-blueprint</feature>
+        <feature version='${camel-osgi-version-range}'>camel-spring</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
-        <feature>jakarta-jws</feature>
-        <feature>jakarta-validation</feature>
+        <feature version="${camel-osgi-jakarta-jws-version}">jakarta-jws</feature>
+        <feature version="[3,4)">jakarta-validation</feature>
         <feature version="[11,12)">jetty</feature>
-        <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/2.5.0-b42</bundle>
+        <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
         <bundle dependency="true">mvn:org.apache.neethi/neethi/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/${cglib-version}_1</bundle>
@@ -765,12 +765,12 @@
         <bundle>mvn:org.apache.camel.karaf/camel-cxf-transport-blueprint/${project.version}</bundle>
     </feature>
     <feature name='camel-cxf-spring' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cxf</feature>
-        <feature version='${camel.osgi.version.range}'>camel-spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cxf</feature>
+        <feature version='${camel-osgi-version-range}'>camel-spring</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-cxf-spring-all/${project.version}</bundle>
     </feature>
     <feature name='camel-datasonnet' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.datasonnet/datasonnet-mapper/${datasonnet-mapper-version}</bundle>
         <bundle dependency='true'>mvn:io.github.classgraph/classgraph/${classgraph-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
@@ -778,11 +778,11 @@
         <bundle>mvn:org.apache.camel.karaf/camel-datasonnet/${project.version}</bundle>
     </feature>
     <feature name='camel-debug' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-debug/${project.version}</bundle>
     </feature>
     <feature name='camel-digitalocean' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
@@ -790,22 +790,22 @@
         <bundle>mvn:org.apache.camel.karaf/camel-digitalocean/${project.version}</bundle>
     </feature>
     <feature name='camel-disruptor' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.lmax/disruptor/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-disruptor/${project.version}</bundle>
     </feature>
     <feature name='camel-djl' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:ai.djl/api/${djl-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-djl/${project.version}</bundle>
     </feature>
     <feature name='camel-dns' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:dnsjava/dnsjava/${dnsjava-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-dns/${project.version}</bundle>
     </feature>
     <feature name='camel-docker' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.github.docker-java/docker-java-api/${docker-java-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.github.docker-java/docker-java-core/${docker-java-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.github.docker-java/docker-java-transport-jersey/${docker-java-version}</bundle>
@@ -814,13 +814,13 @@
         <bundle>mvn:org.apache.camel.karaf/camel-docker/${project.version}</bundle>
     </feature>
     <feature name='camel-drill' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-jdbc</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-jdbc</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.drill.exec/drill-jdbc-all/${apache-drill-version}$Export-Package=org.apache.drill.jdbc.*;version=${apache-drill-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-drill/${project.version}</bundle>
     </feature>
     <feature name='camel-dropbox' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
@@ -829,23 +829,23 @@
         <bundle>mvn:org.apache.camel.karaf/camel-dropbox/${project.version}</bundle>
     </feature>
     <feature name='camel-dynamic-router' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-dynamic-router/${project.version}</bundle>
     </feature>
     <feature name='camel-ehcache' version='${project.version}' start-level='50'>
         <feature>scr</feature>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:org.ehcache/ehcache/${ehcache3-version}</bundle>
         <bundle dependency="true">mvn:javax.cache/cache-api/${jcache-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ehcache/${project.version}</bundle>
     </feature>
     <feature name='camel-elasticsearch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature prerequisite='true'>wrap</feature>
         <feature prerequisite="true">spifly</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[4,5)">http-client</feature>
-        <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/2.5.0-b42</bundle>
+        <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.parsson/parsson/${parson-version}</bundle>
         <bundle dependency='true'>mvn:jakarta.json/jakarta.json-api/${jakarta-json-api-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry-version}</bundle>
@@ -857,9 +857,9 @@
         <bundle>mvn:org.apache.camel.karaf/camel-elasticsearch/${project.version}</bundle>
     </feature>
     <feature name='camel-elasticsearch-rest-client' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature prerequisite='true'>wrap</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.httpcomponents/httpasyncclient/${httpasyncclient-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/${elasticsearch-java-client-version}</bundle>
@@ -867,43 +867,43 @@
         <bundle>mvn:org.apache.camel.karaf/camel-elasticsearch-rest-client/${project.version}</bundle>
     </feature>
     <feature name='camel-elytron' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-undertow</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-undertow</feature>
         <bundle dependency='true'>wrap:mvn:org.wildfly.security.elytron-web/undertow-server/${elytron-web}</bundle>
         <bundle dependency='true'>wrap:mvn:org.wildfly.security/wildfly-elytron/${wildfly-elytron}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-elytron/${project.version}</bundle>
     </feature>
     <feature name='camel-etcd3' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:io.etcd/jetcd-common/${jetcd-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.etcd/jetcd-core/${jetcd-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-etcd3/${project.version}</bundle>
     </feature>
     <feature name='camel-exec' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-exec/${commons-exec-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-exec/${project.version}</bundle>
     </feature>
     <feature name='camel-fastjson' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.alibaba/fastjson/${fastjson-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-fastjson/${project.version}</bundle>
     </feature>
     <feature name='camel-file-watch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.methvin/directory-watcher/${directory-watcher-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-file-watch/${project.version}</bundle>
     </feature>
     <feature name='camel-flatpack' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:net.sf.flatpack/flatpack/${flatpack-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-flatpack/${project.version}</bundle>
     </feature>
     <feature name='camel-flink' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>wrap:mvn:org.apache.flink/flink-java/${flink-version}</bundle>
         <bundle>wrap:mvn:org.apache.flink/flink-streaming-java/${flink-version}</bundle>
         <bundle>wrap:mvn:org.apache.flink/flink-runtime/${flink-version}</bundle>
@@ -911,23 +911,23 @@
         <bundle>mvn:org.apache.camel.karaf/camel-flink/${project.version}</bundle>
     </feature>
     <feature name='camel-fop' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.xmlgraphics/fop-core/${fop-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-fop/${project.version}</bundle>
     </feature>
     <feature name='camel-freemarker' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.freemarker/freemarker/${freemarker-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-freemarker/${project.version}</bundle>
     </feature>
     <feature name='camel-ftp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.github.mwiede/jsch/${jsch-version}</bundle>
         <bundle dependency='true'>mvn:commons-net/commons-net/${commons-net-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ftp/${project.version}</bundle>
     </feature>
     <feature name='camel-geocoder' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle dependency='true'>wrap:mvn:com.google.maps/google-maps-services/${google-maps-services-version}</bundle>
         <bundle dependency='true'>mvn:com.jayway.jsonpath/json-path/${json-path-version}</bundle>
@@ -937,22 +937,22 @@
         <bundle>mvn:org.apache.camel.karaf/camel-geocoder/${project.version}</bundle>
     </feature>
     <feature name='camel-git' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.eclipse.jgit/org.eclipse.jgit/${jgit-version}</bundle>
         <bundle dependency='true'>mvn:com.googlecode.javaewah/JavaEWAH/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-git/${project.version}</bundle>
     </feature>
     <feature name='camel-github' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <!-- the latest version of gson supported by github core is 2.2.2 -->
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.egit.github.core/${egit-github-core-version}_1</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-github/${project.version}</bundle>
     </feature>
     <feature name='camel-google-bigquery' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[33,34)'>guava</feature>
         <feature version='[4,5)'>http-client</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.google.http-client/google-http-client/${google-cloud-http-client-version}$overwrite=merge&amp;Import-Package=com.google.common*;version="[33,34)",*&amp;Export-Package=com.google.api.client.auth*;version=${google-cloud-http-client-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.apis/google-api-services-bigquery/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${google-auth-library-oauth2-http-version}</bundle>
@@ -964,7 +964,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-bigquery/${project.version}</bundle>
     </feature>
     <feature name='camel-google-calendar' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>mvn:com.google.api-client/google-api-client/${google-api-client-version}</bundle>
@@ -981,7 +981,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-calendar/${project.version}</bundle>
     </feature>
     <feature name='camel-google-drive' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[33,34)'>guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>wrap:mvn:com.google.api-client/google-api-client/${google-api-client-version}$overwrite=merge&amp;Import-Package=com.google.common*;version="[33,34)",*</bundle>
@@ -1001,7 +1001,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-drive/${project.version}</bundle>
     </feature>
     <feature name='camel-google-functions' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>wrap:mvn:com.google.http-client/google-http-client/${google-cloud-http-client-version}$overwrite=merge&amp;Import-Package=com.google.common*;version="[33,34)",*</bundle>
@@ -1015,7 +1015,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-functions/${project.version}</bundle>
     </feature>
     <feature name='camel-google-mail' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[33,34)'>guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>mvn:com.google.api-client/google-api-client/${google-api-client-version}</bundle>
@@ -1032,7 +1032,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-mail/${project.version}</bundle>
     </feature>
     <feature name='camel-google-pubsub' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/${auto-detect-version}</bundle>
@@ -1071,9 +1071,9 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub/${project.version}</bundle>
     </feature>
     <feature name='camel-google-secret-manager' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/gax/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${google-auth-library-oauth2-http-version}</bundle>
@@ -1085,8 +1085,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-secret-manager/${project.version}</bundle>
     </feature>
     <feature name='camel-google-sheets' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>mvn:com.google.api-client/google-api-client/${google-api-client-version}</bundle>
@@ -1103,11 +1103,11 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-sheets/${project.version}</bundle>
     </feature>
     <feature name='camel-google-storage' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cloudevents</feature>
-        <feature version='${camel.osgi.version.range}'>camel-gson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
+        <feature version='${camel-osgi-version-range}'>camel-gson</feature>
         <feature version="[33,34)">guava</feature>
         <feature version='[4,5)'>http-client</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.google.api-client/google-api-client/${google-api-client-version}</bundle>
         <bundle dependency='true'>mvn:com.google.http-client/google-http-client-apache-v2/${google-cloud-http-client-version}</bundle>
         <bundle dependency='true'>mvn:org.threeten/threetenbp/${auto-detect-version}</bundle>
@@ -1131,29 +1131,29 @@
         <bundle>mvn:org.apache.camel.karaf/camel-google-storage/${project.version}</bundle>
     </feature>
     <feature name='camel-grape' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.groovy/groovy/${groovy-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-grape/${project.version}</bundle>
     </feature>
     <feature name='camel-graphql' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-graphql/${project.version}</bundle>
     </feature>
     <feature name='camel-groovy' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.groovy/groovy/${groovy-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-groovy/${project.version}</bundle>
     </feature>
     <feature name='camel-grok' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.krakens/java-grok/${java-grok-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-grok/${project.version}</bundle>
     </feature>
     <feature name='camel-grpc' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:com.auth0/java-jwt/${grpc-java-jwt-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
@@ -1167,39 +1167,39 @@
         <bundle>mvn:org.apache.camel.karaf/camel-grpc/${project.version}</bundle>
     </feature>
     <feature name='camel-gson' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.google.code.gson/gson/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-gson/${project.version}</bundle>
     </feature>
     <feature name='camel-guava-eventbus' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[33,34)'>guava</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-guava-eventbus/${project.version}</bundle>
     </feature>
     <feature name='camel-hashicorp-vault' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.vault/spring-vault-core/${spring-vault-core-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-hashicorp-vault/${project.version}</bundle>
     </feature>
     <feature name='camel-hazelcast' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.hazelcast/hazelcast/${hazelcast-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-hazelcast/${project.version}</bundle>
     </feature>
     <feature name='camel-headersmap' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <!-- Need to wrap the bundle because it doesn't export properly com.cedarsoftware.util -->
         <bundle dependency='true'>wrap:mvn:com.cedarsoftware/java-util/${java-util-version}$overwrite=merge&amp;Export-Package=com.cedarsoftware.util*;version=${java-util-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-headersmap/${project.version}</bundle>
     </feature>
     <feature name='camel-hl7' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-netty</feature>
+        <feature version='${camel-osgi-version-range}'>camel-netty</feature>
         <bundle dependency='true'>wrap:mvn:ca.uhn.hapi/hapi-base/${hapi-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-hl7/${project.version}</bundle>
     </feature>
     <feature name='camel-http' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[5,6)'>http-client</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
@@ -1209,7 +1209,7 @@
         <bundle dependency="true">wrap:mvn:org.apache.httpcomponents.core5/httpcore5-h2/${httpcore-version}</bundle>
     </feature>
     <feature name='camel-ical' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle dependency='true'>mvn:commons-validator/commons-validator/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:commons-beanutils/commons-beanutils/${commons-beanutils-version}</bundle>
@@ -1219,7 +1219,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-ical/${project.version}</bundle>
     </feature>
     <feature name='camel-iec60870' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <feature version='[33,34)'>guava</feature>
         <bundle dependency='true'>mvn:org.eclipse.neoscada.protocols/org.eclipse.neoscada.protocol.iec60870/${neoscada-version}</bundle>
@@ -1240,13 +1240,13 @@
 
             Please refer to the component page (https://camel.apache.org/ignite.html) and to the Ignite docs (https://apacheignite.readme.io/docs/osgi-installation-in-karaf#preparatory-steps) for more information.]]>
         </details>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.ignite/ignite-core/${ignite-version}</bundle>
         <bundle dependency='true'>mvn:javax.cache/cache-api/${jcache-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ignite/${project.version}</bundle>
     </feature>
     <feature name='camel-influxdb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/logging-interceptor/${squareup-okhttp-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp/${squareup-okhttp-version}</bundle>
@@ -1259,7 +1259,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-influxdb/${project.version}</bundle>
     </feature>
     <feature name='camel-influxdb2' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.influxdb/influxdb-client-java/${influx-client-java-driver-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.influxdb/influxdb-client-core/${influx-client-java-driver-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.influxdb/influxdb-client-utils/${influx-client-java-driver-version}</bundle>
@@ -1282,24 +1282,24 @@
         <bundle>mvn:org.apache.camel.karaf/camel-influxdb2/${project.version}</bundle>
     </feature>
     <feature name='camel-irc' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.schwering/irclib/${irclib-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-irc/${project.version}</bundle>
     </feature>
     <feature name='camel-ironmq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ironmq/${ironmq-version}_1</bundle>
         <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ironmq/${project.version}</bundle>
     </feature>
     <feature name='camel-jackson' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jackson/${project.version}</bundle>
     </feature>
     <feature name='camel-jackson-avro' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <feature version='[33,34)'>guava</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.avro/avro/${auto-detect-version}</bundle>
@@ -1310,48 +1310,48 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jackson-avro/${project.version}</bundle>
     </feature>
     <feature name='camel-jackson-protobuf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-protobuf/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jackson-protobuf/${project.version}</bundle>
     </feature>
     <feature name='camel-jacksonxml' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jacksonxml/${project.version}</bundle>
     </feature>
     <feature name='camel-jasypt' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.jasypt/jasypt/${jasypt-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jasypt/${project.version}</bundle>
     </feature>
     <feature name='camel-javascript' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.graalvm.polyglot/polyglot/${graaljs-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-javascript/${project.version}</bundle>
     </feature>
     <feature name='camel-jaxb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jaxb/${project.version}</bundle>
     </feature>
     <feature name='camel-jcache' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:javax.cache/cache-api/${jcache-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jcache/${project.version}</bundle>
     </feature>
     <feature name='camel-jcr' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:javax.jcr/jcr/${jcr-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.jackrabbit/jackrabbit-jcr-commons/${jackrabbit-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jcr/${project.version}</bundle>
     </feature>
     <feature name='camel-jdbc' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jdbc/${project.version}</bundle>
     </feature>
     <feature name='camel-jetty' version='${project.version}' start-level='50'>
         <feature version="[12,13)">jetty</feature>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:org.eclipse.jetty.ee10/jetty-ee10-servlet/${jetty-version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty.ee10/jetty-ee10-servlets/${jetty-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
@@ -1361,7 +1361,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jetty/${project.version}</bundle>
     </feature>
     <feature name='camel-jira' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[33,34)'>guava</feature>
         <feature version='[4,5)'>http-client</feature>
         <bundle dependency='true'>wrap:mvn:com.atlassian.event/atlassian-event/${auto-detect-version}</bundle>
@@ -1380,23 +1380,23 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jira/${project.version}</bundle>
     </feature>
     <feature name='camel-jfr' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jfr/${project.version}</bundle>
     </feature>
     <feature name='camel-jgroups' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.jgroups/jgroups/${jgroups-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jgroups/${project.version}</bundle>
     </feature>
     <feature name='camel-jgroups-raft' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.jgroups/jgroups/${jgroups-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.jgroups/jgroups-raft/${jgroups-raft-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jgroups-raft/${project.version}</bundle>
     </feature>
     <feature name="camel-jms" version="${project.version}" start-level="50">
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version="${camel.osgi.spring.version}">spring-jms</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="${camel-osgi-spring-version}">spring-jms</feature>
         <!-- The SMX bundle of Spring JMS doesn't contain micrometer as part of its import packages, see https://issues.apache.org/jira/browse/SM-5706,
             so we need to override the imports by wrapping the bundle until it is fixed in the SMX bundle project and in Karaf.
             The Bundle-Version is updated by Bundle-Version=${spring-version}.2 so that the updated bundle is used
@@ -1410,61 +1410,61 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jms/${project.version}</bundle>
     </feature>
     <feature name='camel-jmx' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jmx/${project.version}</bundle>
     </feature>
     <feature name='camel-jolt' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.bazaarvoice.jolt/jolt-core/${jolt-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jolt/${project.version}</bundle>
     </feature>
     <feature name='camel-jooq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.jooq/jooq/${jooq-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.r2dbc/r2dbc-spi/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jooq/${project.version}</bundle>
     </feature>
     <feature name='camel-joor' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <!-- wrap protocol needed because joor has a Require-Capability: osgi.ee;filter:="(osgi.ee=UNKNOWN) in its manifest.
          The wrap does not support & , so it's not possible to add version to the filter -->
         <bundle dependency='true'>wrap:mvn:org.jooq/joor/${joor-version}$overwrite=merge&amp;Require-Capability=osgi.ee;filter:="(osgi.ee=JavaSE)"</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-joor/${project.version}</bundle>
     </feature>
     <feature name='camel-jpa' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-orm</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-orm</feature>
         <bundle dependency='true'>mvn:jakarta.persistence/jakarta.persistence-api/${jakarta-persistence-api-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jpa/${project.version}</bundle>
     </feature>
     <feature name="camel-jq" version="${project.version}" start-level="50">
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:net.thisptr/jackson-jq/${jackson-jq-version}$overwrite=merge&amp;Export-Package=net*;version=${jackson-jq-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.jruby.jcodings/jcodings/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.jruby.joni/joni/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jq/${project.version}</bundle>
     </feature>
     <feature name='camel-jsch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-ftp</feature>
+        <feature version='${camel-osgi-version-range}'>camel-ftp</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-jsch/${project.version}</bundle>
     </feature>
     <feature name='camel-jslt' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.schibsted.spt.data/jslt/${jslt-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jslt/${project.version}</bundle>
     </feature>
     <feature name='camel-jsonata' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.dashjoin/jsonata/${jsonata-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jsonata/${project.version}</bundle>
     </feature>
     <feature name='camel-json-patch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.github.java-json-tools/json-patch/${json-patch-version}$overwrite=merge&amp;Export-Package=com.github.fge*;version=${json-patch-version}&amp;Import-Package=com.fasterxml*,com.github*;javax*</bundle>
         <bundle dependency='true'>wrap:mvn:com.github.java-json-tools/jackson-coreutils/${auto-detect-version}$overwrite=merge&amp;Export-Package=com.github.fge*;version=${auto-detect-version}&amp;Import-Package=com.fasterxml*,com.github*;javax*</bundle>
         <bundle dependency='true'>mvn:com.github.java-json-tools/msg-simple/${auto-detect-version}</bundle>
@@ -1472,8 +1472,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-json-patch/${project.version}</bundle>
     </feature>    
     <feature name='camel-json-validator' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.networknt/json-schema-validator/${networknt-json-schema-validator-version}</bundle>
         <bundle dependency='true'>mvn:com.ethlo.time/itu/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2-version}</bundle>
@@ -1481,20 +1481,20 @@
         <bundle>mvn:org.apache.camel.karaf/camel-json-validator/${project.version}</bundle>
     </feature>
     <feature name='camel-json-api' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.github.jasminb/jsonapi-converter/${jasminb-jsonapi-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jsonapi/${project.version}</bundle>
     </feature>
     <feature name='camel-jsonb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:jakarta.json/jakarta.json-api/${jakarta-json-api-version}</bundle>
         <bundle dependency='true'>mvn:jakarta.json.bind/jakarta.json.bind-api/${jakarta-json-bind-api-version}</bundle>
         <bundle dependency='true'>mvn:org.eclipse/yasson/${yasson-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jsonb/${project.version}</bundle>
     </feature>
     <feature name='camel-jsonpath' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.jayway.jsonpath/json-path/${json-path-version}</bundle>
         <bundle dependency='true'>mvn:net.minidev/json-smart/${json-smart-version}</bundle>
         <bundle dependency='true'>mvn:net.minidev/accessors-smart/${json-smart-version}</bundle>
@@ -1502,7 +1502,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jsonpath/${project.version}</bundle>
     </feature>
     <feature name='camel-jta' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:jakarta.transaction/jakarta.transaction-api/${jakarta-transaction-api-version}</bundle>
         <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.cdi-api/${jakarta-enterprise-cdi-api-version}</bundle>
         <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.lang-model/${jakarta-enterprise-cdi-api-version}</bundle>
@@ -1512,27 +1512,27 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jta/${project.version}</bundle>
     </feature>
     <feature name='camel-jte' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:gg.jte/jte-runtime/${jte-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jte/${project.version}</bundle>
     </feature>
     <feature name='camel-jt400' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:net.sf.jt400/jt400/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jt400/${project.version}</bundle>
     </feature>
     <feature name='camel-kafka' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.kafka/kafka-clients/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-kafka/${project.version}</bundle>
     </feature>
     <feature name='camel-kamelet' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-kamelet/${project.version}</bundle>
     </feature>
     <feature name='camel-kubernetes' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:io.fabric8/kubernetes-client/${kubernetes-client-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.fabric8/kubernetes-client-api/${kubernetes-client-version}</bundle>
         <bundle dependency='true'>mvn:io.fabric8/kubernetes-model-admissionregistration/${kubernetes-client-version}</bundle>
@@ -1572,16 +1572,16 @@
         <bundle>mvn:org.apache.camel.karaf/camel-kubernetes/${project.version}</bundle>
     </feature>
     <feature name='camel-kudu' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.kudu/kudu-client/${kudu-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-kudu/${project.version}</bundle>
     </feature>
     <feature name='camel-ldap' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-ldap/${project.version}</bundle>
     </feature>
     <feature name='camel-ldif' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.directory.api/api-i18n/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-api/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-ber/${auto-detect-version}</bundle>
@@ -1602,44 +1602,44 @@
         <bundle>mvn:org.apache.camel.karaf/camel-ldif/${project.version}</bundle>
     </feature>
     <feature name='camel-leveldb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:org.fusesource.leveldbjni/leveldbjni-all/${leveldbjni-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-leveldb/${project.version}</bundle>
     </feature>
     <feature name='camel-lra' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-lra/${project.version}</bundle>
     </feature>
     <feature name='camel-lucene' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.lucene/lucene-core/${lucene-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.lucene/lucene-queryparser/${lucene-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.lucene/lucene-analysis-common/${lucene-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-lucene/${project.version}</bundle>
     </feature>
     <feature name='camel-lumberjack' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-lumberjack/${project.version}</bundle>
     </feature>
     <feature name='camel-lzf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.ning/compress-lzf/${compress-lzf-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-lzf/${project.version}</bundle>
     </feature>
     <feature name='camel-mail' version='${project.version}' start-level='50'>
         <feature prerequisite="true">spifly</feature>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:jakarta.mail/jakarta.mail-api/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.eclipse.angus/angus-mail/${angus-mail-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mail/${project.version}</bundle>
     </feature>
     <feature name='camel-mail-microsoft-oauth' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-mail</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-mail</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:com.microsoft.azure/msal4j/${msal4j-version}$overwrite=merge&amp;Import-Package=com.sun.net.httpserver;resolution:=optional,*</bundle>
         <bundle dependency='true'>mvn:com.nimbusds/content-type/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.nimbusds/nimbus-jose-jwt/${nimbus-jose-jwt}</bundle>
@@ -1652,25 +1652,25 @@
         <bundle>mvn:org.apache.camel.karaf/camel-mail-microsoft-oauth/${project.version}</bundle>
     </feature>
     <feature name='camel-mapstruct' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.mapstruct/mapstruct/${mapstruct-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mapstruct/${project.version}</bundle>
     </feature>
     <feature name='camel-master' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-master/${project.version}</bundle>
     </feature>
     <feature name='camel-metrics' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${metrics-version}</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-jmx/${metrics-version}</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-json/${metrics-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-metrics/${project.version}</bundle>
     </feature>
     <feature name='camel-micrometer' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-core/${micrometer-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-registry-jmx/${micrometer-version}</bundle>
@@ -1679,8 +1679,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-micrometer/${project.version}</bundle>
     </feature>
     <feature name='camel-micrometer-prometheus' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-micrometer</feature>
-        <feature version='${camel.osgi.version.range}'>camel-platform-http-main</feature>
+        <feature version='${camel-osgi-version-range}'>camel-micrometer</feature>
+        <feature version='${camel-osgi-version-range}'>camel-platform-http-main</feature>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-registry-prometheus/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.prometheus/simpleclient_common/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:io.prometheus/simpleclient/${auto-detect-version}</bundle>
@@ -1691,12 +1691,12 @@
         <bundle>mvn:org.apache.camel.karaf/camel-micrometer-prometheus/${project.version}</bundle>
     </feature>
     <feature name='camel-mina' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mina/${project.version}</bundle>
     </feature>
     <feature name='camel-minio' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.minio/minio/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress-version}</bundle>
@@ -1704,48 +1704,48 @@
         <bundle>mvn:org.apache.camel.karaf/camel-minio/${project.version}</bundle>
     </feature>
     <feature name='camel-mllp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-mllp/${project.version}</bundle>
     </feature>
     <feature name='camel-mongodb' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
         <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}</bundle>
         <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mongodb/${project.version}</bundle>
     </feature>
     <feature name='camel-mongodb-gridfs' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
         <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
         <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}</bundle>
         <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mongodb-gridfs/${project.version}</bundle>
     </feature>
     <feature name='camel-mustache' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.github.spullara.mustache.java/compiler/${mustache-java-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mustache/${project.version}</bundle>
     </feature>
     <feature name='camel-mvel' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.ow2.asm/asm/${asm-version}</bundle>
         <bundle dependency='true'>mvn:org.mvel/mvel2/${mvel-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mvel/${project.version}</bundle>
     </feature>
     <feature name='camel-mybatis' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.mybatis/mybatis/${mybatis-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-mybatis/${project.version}</bundle>
     </feature>
     <feature name='camel-nats' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.nats/jnats/${jnats-version}$overwrite=merge&amp;Export-Package=io.nats.client.*;version=${jnats-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-nats/${project.version}</bundle>
     </feature>
     <feature name='camel-netty' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
@@ -1753,38 +1753,38 @@
         <bundle>mvn:org.apache.camel.karaf/camel-netty/${project.version}</bundle>
     </feature>
     <feature name='camel-netty-http' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-netty</feature>
+        <feature version='${camel-osgi-version-range}'>camel-netty</feature>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-http-base/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-netty-http/${project.version}</bundle>
     </feature>
     <feature name='camel-nitrite' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.dizitart/nitrite/${nitrite-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-nitrite/${project.version}</bundle>
     </feature>
     <feature name='camel-oaipmh' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[5,6)">http-client</feature>
         <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime2-version}</bundle>
         <bundle dependency='true'>mvn:org.jsoup/jsoup/${jsoup-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-oaipmh/${project.version}</bundle>
     </feature>
     <feature name='camel-observation' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-tracing</feature>
+        <feature version='${camel-osgi-version-range}'>camel-tracing</feature>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-observation/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-tracing/${micrometer-tracing-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-observation/${project.version}</bundle>
     </feature>
     <feature name='camel-ognl' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:ognl/ognl/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ognl/${project.version}</bundle>
     </feature>
     <feature name='camel-olingo2' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclient-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
@@ -1794,10 +1794,10 @@
         <bundle>mvn:org.apache.camel.karaf/camel-olingo2/${project.version}</bundle>
     </feature>
     <feature name='camel-olingo4' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[4,5)">http-client</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:org.apache.olingo/odata-commons-api/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.olingo/odata-commons-core/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.olingo/odata-client-api/${auto-detect-version}</bundle>
@@ -1821,11 +1821,11 @@
         <bundle>mvn:org.apache.camel.karaf/camel-olingo4/${project.version}</bundle>
     </feature>
     <feature name='camel-openapi-java' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[3,4)'>jakarta-validation</feature>
-        <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-tooling-util/${camel.version}$Export-Package=org.apache.camel*;version=${camel.version}</bundle>
-        <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-xml-io/${camel.version}$Export-Package=org.apache.camel*;version=${camel.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-tooling-util/${camel-version}$Export-Package=org.apache.camel*;version=${camel-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-xml-io/${camel-version}$Export-Package=org.apache.camel*;version=${camel-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml-version}</bundle>
@@ -1838,8 +1838,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-openapi-java/${project.version}</bundle>
     </feature>
     <feature name='camel-opensearch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>mvn:jakarta.json/jakarta.json-api/${jakarta-json-api-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.httpcomponents/httpasyncclient/${httpasyncclient-version}</bundle>
@@ -1849,8 +1849,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-opensearch/${project.version}</bundle>
     </feature>
     <feature name='camel-openstack' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[33,34)'>guava</feature>
         <!-- use wrap to override the guava version -->
         <bundle dependency='true'>wrap:mvn:com.github.openstack4j.core/openstack4j-core/${openstack4j-version}$overwrite=merge&amp;Import-Package=com.fasterxml*,com.github*,javax*,org*,com.google*;version='[33,34)'</bundle>
@@ -1865,8 +1865,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-openstack/${project.version}</bundle>
     </feature>
     <feature name='camel-opentelemetry' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-tracing</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-tracing</feature>
         <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-sdk/${opentelemetry-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry-version}</bundle>
@@ -1874,25 +1874,25 @@
         <bundle>mvn:org.apache.camel.karaf/camel-opentelemetry/${project.version}</bundle>
     </feature>
     <feature name='camel-optaplanner' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.kie/kie-api/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.optaplanner/optaplanner-core-impl/${optaplanner-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-optaplanner/${project.version}</bundle>
     </feature>
     <feature name='camel-paho' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/${paho-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-paho/${project.version}</bundle>
     </feature>
 <!--    Paho v5 does not work in OSGi: https://github.com/eclipse/paho.mqtt.java/issues/857-->
     <feature name='camel-paho-mqtt5' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>wrap:mvn:org.eclipse.paho/org.eclipse.paho.mqttv5.client/${paho-version}$overwrite=merge&amp;Export-Package=org.eclipse.paho.mqttv5.*;version=${paho-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-paho-mqtt5/${project.version}</bundle>
     </feature>
     <feature name='camel-parquet-avro' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.avro/avro/${avro-version}</bundle>
@@ -1903,7 +1903,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-parquet-avro/${project.version}</bundle>
     </feature>
     <feature name='camel-pdf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.pdfbox/pdfbox/${pdfbox-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.pdfbox/pdfbox-io/${pdfbox-version}</bundle>
@@ -1912,28 +1912,28 @@
         <bundle>mvn:org.apache.camel.karaf/camel-pdf/${project.version}</bundle>
     </feature>
     <feature name='camel-pg-replication-slot' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.postgresql/postgresql/${pgjdbc-driver-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pg-replication-slot/${project.version}</bundle>
     </feature>
     <feature name='camel-pgevent' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:com.impossibl.pgjdbc-ng/pgjdbc-ng/${pgjdbc-ng-driver-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pgevent/${project.version}</bundle>
     </feature>
     <feature name='camel-platform-http' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-http-base/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-platform-http/${project.version}</bundle>
     </feature>
     <feature name='camel-platform-http-main' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-platform-http-vertx</feature>
+        <feature version='${camel-osgi-version-range}'>camel-platform-http-vertx</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-platform-http-main/${project.version}</bundle>
     </feature>
     <feature name='camel-platform-http-vertx' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-platform-http</feature>
-        <feature version='${camel.osgi.version.range}'>camel-vertx-common</feature>
+        <feature version='${camel-osgi-version-range}'>camel-platform-http</feature>
+        <feature version='${camel-osgi-version-range}'>camel-vertx-common</feature>
         <bundle dependency='true'>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-auth-common/${vertx-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-auth-properties/${vertx-version}</bundle>
@@ -1942,8 +1942,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-platform-http-vertx/${project.version}</bundle>
     </feature>
     <feature name='camel-plc4x' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:org.apache.plc4x/plc4j-api/${plc4x-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.plc4x/plc4j-scraper/${plc4x-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.plc4x/plc4j-connection-cache/${plc4x-version}</bundle>
@@ -1955,11 +1955,11 @@
         <bundle>mvn:org.apache.camel.karaf/camel-plc4x/${project.version}</bundle>
     </feature>
     <feature name='camel-printer' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-printer/${project.version}</bundle>
     </feature>
     <feature name='camel-protobuf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[32,33)">guava</feature>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${protobuf-version}</bundle>
@@ -1969,23 +1969,23 @@
         <bundle>mvn:org.apache.camel.karaf/camel-protobuf/${project.version}</bundle>
     </feature>
     <feature name='camel-pubnub' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.pubnub/pubnub-gson/${pubnub-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pubnub/${project.version}</bundle>
     </feature>
     <feature name='camel-pulsar' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.pulsar/pulsar-client-admin/${pulsar-version}$Export-Package=org.apache.pulsar*;version=${pulsar-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pulsar/${project.version}</bundle>
     </feature>
     <feature name='camel-python' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.python/jython-standalone/${jython-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-python/${project.version}</bundle>
     </feature>
     <feature name='camel-quartz' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-cron</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cron</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.c3p0/${c3p0-version}_1</bundle>
         <bundle dependency='true'>mvn:com.zaxxer/HikariCP-java7/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.quartz-scheduler/quartz/${quartz-version}$overwrite=merge&amp;DynamicImport-Package=org.apache.camel.component.quartz</bundle>
@@ -1999,30 +1999,30 @@
         <bundle>mvn:org.apache.camel.karaf/camel-quickfix/${project.version}</bundle>
     </feature>
     <feature name='camel-reactive-executor-tomcat' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-reactive-executor-tomcat/${project.version}</bundle>
     </feature>
     <feature name='camel-reactive-executor-vertx' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-reactive-executor-vertx/${project.version}</bundle>
     </feature>
     <feature name='camel-reactive-streams' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-reactive-streams/${project.version}</bundle>
     </feature>
     <feature name='camel-reactor' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-reactive-streams</feature>
+        <feature version='${camel-osgi-version-range}'>camel-reactive-streams</feature>
         <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-reactor/${project.version}</bundle>
     </feature>
     <feature name='camel-redis' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[4.1,5)'>netty</feature>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
         <bundle dependency='true'>mvn:org.redisson/redisson/${redisson-version}</bundle>
         <bundle dependency='true'>mvn:com.esotericsoftware/kryo/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.esotericsoftware/minlog/${auto-detect-version}</bundle>
@@ -2034,7 +2034,7 @@
         <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-transport-classes-kqueue/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.25.Final</bundle>
+        <bundle dependency='true'>mvn:io.netty.incubator/netty-incubator-transport-classes-io_uring/${netty-incubator-transport-classes-io_uring-version}</bundle>
         <bundle dependency='true'>mvn:io.reactivex.rxjava3/rxjava/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
         <bundle dependency='true'>mvn:javax.cache/cache-api/${jcache-version}</bundle>
@@ -2044,7 +2044,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-redis/${project.version}</bundle>
     </feature>
     <feature name='camel-resilience4j' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.github.resilience4j/resilience4j-core/${resilience4j-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.github.resilience4j/resilience4j-bulkhead/${resilience4j-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.github.resilience4j/resilience4j-circuitbreaker/${resilience4j-version}</bundle>
@@ -2053,12 +2053,12 @@
         <bundle>mvn:org.apache.camel.karaf/camel-resilience4j/${project.version}</bundle>
     </feature>
     <feature name='camel-resourceresolver-github' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-resourceresolver-github/${project.version}</bundle>
     </feature>
     <feature name='camel-rest-openapi' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-platform-http</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-platform-http</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:io.swagger.parser.v3/swagger-parser-core/${swagger-openapi3-java-parser-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.swagger.parser.v3/swagger-parser-v3/${swagger-openapi3-java-parser-version}</bundle>
         <bundle dependency='true'>mvn:io.swagger.core.v3/swagger-core-jakarta/${swagger-openapi3-version}</bundle>
@@ -2067,14 +2067,14 @@
         <bundle>mvn:org.apache.camel.karaf/camel-rest-openapi/${project.version}</bundle>
     </feature>
     <feature name='camel-robotframework' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.robotframework/robotframework/${robotframework-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.python/jython/${jython-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.python/jython-standalone/${jython-standalone-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-robotframework/${project.version}</bundle>
     </feature>
     <feature name='camel-rocketmq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.rocketmq/rocketmq-acl/${rocketmq-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.rocketmq/rocketmq-client/${rocketmq-version}</bundle>
@@ -2083,20 +2083,20 @@
         <bundle>mvn:org.apache.camel.karaf/camel-rocketmq/${project.version}</bundle>
     </feature>
     <feature name='camel-rss' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-atom</feature>
+        <feature version='${camel-osgi-version-range}'>camel-atom</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/${auto-detect-version:alias=org.jdom/jdom2}_1</bundle>
         <bundle dependency="true">mvn:com.rometools/rome/${rome-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-rss/${project.version}</bundle>
     </feature>
     <feature name='camel-rxjava' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-reactive-streams</feature>
+        <feature version='${camel-osgi-version-range}'>camel-reactive-streams</feature>
         <bundle dependency='true'>mvn:io.reactivex.rxjava2/rxjava/${rxjava2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-rxjava/${project.version}</bundle>
     </feature>
     <feature name='camel-salesforce' version='${project.version}' start-level='50'>
         <feature version="[12,13)">jetty</feature>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[32,33)">guava</feature>
         <feature version="[3,4)">jakarta-validation</feature>        
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
@@ -2122,28 +2122,28 @@
         <bundle>mvn:org.apache.camel.karaf/camel-salesforce/${project.version}</bundle>
     </feature>   
     <feature name='camel-sap-netweaver' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-sap-netweaver/${project.version}</bundle>
     </feature>
     <feature name='camel-saxon' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">wrap:mvn:net.sf.saxon/Saxon-HE/${saxon-version}</bundle>
         <bundle dependency="true">wrap:mvn:org.xmlresolver/xmlresolver/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-saxon/${project.version}</bundle>
     </feature>
     <feature name='camel-schematron' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-schematron/${project.version}</bundle>
     </feature>
     <feature name='camel-service' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-service/${project.version}</bundle>
     </feature>
     <feature name='camel-servicenow' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[5,6)">jakarta-servlet</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson2-version}</bundle>
@@ -2162,7 +2162,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-servicenow/${project.version}</bundle>
     </feature>
     <feature name='camel-servlet' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-http-base/${project.version}</bundle>
@@ -2170,7 +2170,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-servlet/${project.version}</bundle>
     </feature>
     <feature name='camel-shiro' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.shiro/shiro-core/${shiro-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.shiro/shiro-event/${shiro-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.shiro/shiro-lang/${shiro-version}</bundle>
@@ -2187,16 +2187,16 @@
         <bundle>mvn:org.apache.camel.karaf/camel-shiro/${project.version}</bundle>
     </feature>
     <feature name='camel-sjms' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:jakarta.jms/jakarta.jms-api/${jakarta-jms-api-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-sjms/${project.version}</bundle>
     </feature>
     <feature name='camel-sjms2' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-sjms</feature>
+        <feature version='${camel-osgi-version-range}'>camel-sjms</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-sjms2/${project.version}</bundle>
     </feature>
     <feature name='camel-slack' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.slack.api/slack-api-client/${slack-api-model-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.slack.api/slack-api-model/${slack-api-model-version}</bundle>
@@ -2209,33 +2209,33 @@
         <bundle>mvn:org.apache.camel.karaf/camel-smb/${project.version}</bundle>
     </feature>
     <feature name='camel-smpp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.jsmpp/jsmpp/${jsmpp-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-smpp/${project.version}</bundle>
     </feature>
     <feature name='camel-snakeyaml' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-snakeyaml/${project.version}</bundle>
     </feature>
     <feature name='camel-snmp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.snmp4j/snmp4j/${snmp4j-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-snmp/${project.version}</bundle>
     </feature>
     <feature name='camel-soap' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jaxb</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jaxb</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-soap/${project.version}</bundle>
     </feature>
     <feature name='camel-splunk' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.splunk/${splunk-version}</bundle>
         <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-splunk/${project.version}</bundle>
     </feature>
     <feature name='camel-splunk-hec' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle dependency='true'>mvn:commons-validator/commons-validator/${commons-validator-version}</bundle>
         <bundle dependency='true'>mvn:commons-beanutils/commons-beanutils/${commons-beanutils-version}</bundle>
@@ -2244,30 +2244,30 @@
         <bundle>mvn:org.apache.camel.karaf/camel-splunk-hec/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-batch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.batch/spring-batch-core/${spring-batch-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.springframework.batch/spring-batch-infrastructure/${spring-batch-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-batch/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-jdbc' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-jdbc</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-jdbc</feature>
+        <feature version='${camel-osgi-version-range}'>camel-jdbc</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-jdbc</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-jdbc/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-ldap' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.ldap/spring-ldap-core/${spring-ldap-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-ldap/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-main' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-spring</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-main/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-rabbitmq' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-tx</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-messaging</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-tx</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-messaging</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.retry/spring-retry/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:com.rabbitmq/amqp-client/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-commons/${micrometer-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
@@ -2276,21 +2276,21 @@
         <bundle>mvn:org.apache.camel.karaf/camel-spring-rabbitmq/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-redis' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-tx</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-tx</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.data/spring-data-commons/${spring-data-redis-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.springframework.data/spring-data-redis/${spring-data-redis-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-redis/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-security' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.security/spring-security-core/${spring-security-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-security/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-ws' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-xslt-saxon</feature>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-xslt-saxon</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.ws/spring-ws-core/${spring-ws-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.springframework.ws/spring-xml/${spring-ws-version}</bundle>
@@ -2298,26 +2298,26 @@
         <bundle>mvn:org.apache.camel.karaf/camel-spring-ws/${project.version}</bundle>
     </feature>
     <feature name='camel-sql' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-tx</feature>
-        <feature version='${camel.osgi.spring.version}'>spring-jdbc</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-tx</feature>
+        <feature version='${camel-osgi-spring-version}'>spring-jdbc</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-sql/${project.version}</bundle>
     </feature>
     <feature name='camel-ssh' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version="${bouncycastle-version}">bouncycastle</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="[${bouncycastle-version},2)">bouncycastle</feature>
         <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.sshd/sshd-osgi/${sshd-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ssh/${project.version}</bundle>
     </feature>
     <feature name='camel-stax' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.fasterxml.woodstox/woodstox-core/${woodstox-core-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-stax/${project.version}</bundle>
     </feature>
     <feature name='camel-stitch' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
@@ -2333,7 +2333,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-stitch/${project.version}</bundle>
     </feature>
     <feature name='camel-stomp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <!--
             The bundle wrap:mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1 provides javax.jms package
             required by mvn:org.fusesource.stompjms/stompjms-client/${stompjms-version} bundle. The wrap protocol is used because
@@ -2347,40 +2347,40 @@
         <bundle>mvn:org.apache.camel.karaf/camel-stomp/${project.version}</bundle>
     </feature>    
     <feature name='camel-stream' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-stream/${project.version}</bundle>
     </feature>
     <feature name='camel-string-template' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.antlr/ST4/${stringtemplate-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-stringtemplate/${project.version}</bundle>
     </feature>
     <feature name='camel-syslog' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-netty</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-netty</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-syslog/${project.version}</bundle>
     </feature>
     <feature name='camel-swift' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.prowidesoftware/pw-swift-core/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.prowidesoftware/pw-iso20022/${prowide-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-swift/${project.version}</bundle>
     </feature>
     <feature name='camel-tarfile' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-tarfile/${project.version}</bundle>
     </feature>
     <feature name='camel-telegram' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-webhook</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-webhook</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-telegram/${project.version}</bundle>
     </feature>
     <feature name='camel-test' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.junit.platform/junit-platform-commons/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.junit.platform/junit-platform-engine/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.junit.platform/junit-platform-launcher/${auto-detect-version:alias=org.junit.platform/junit-platform-engine}</bundle>
@@ -2395,53 +2395,53 @@
         <bundle>mvn:org.apache.camel.karaf/camel-test-junit5/${project.version}</bundle>
     </feature>
     <feature name='camel-test-spring' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-spring</feature>
-        <feature version='${camel.osgi.version.range}'>camel-test</feature>
+        <feature version='${camel-osgi-version-range}'>camel-spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-test</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework/spring-test/${spring-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-test-spring/${project.version}</bundle>
     </feature>
     <feature name='camel-threadpoolfactory-vertx' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-threadpoolfactory-vertx/${project.version}</bundle>
     </feature>
     <feature name='camel-thrift' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle dependency='true'>mvn:org.javassist/javassist/${javassist-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.thrift/libthrift/${libthrift-version}$overwrite=merge&amp;Export-Package=org.apache.thrift*;version=${libthrift-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-thrift/${project.version}</bundle>
     </feature>
     <feature name='camel-thymeleaf' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.thymeleaf/thymeleaf/${thymeleaf-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-thymeleaf/${project.version}</bundle>
     </feature>
     <feature name='camel-tika' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.tika/tika-core/${tika-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.tika/tika-parser-html-commons/${tika-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-tika/${project.version}</bundle>
     </feature>
     <feature name='camel-tracing' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-tracing/${project.version}</bundle>
     </feature>
     <feature name='camel-twilio' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[4,5)">http-client</feature>
         <bundle dependency='true'>wrap:mvn:com.twilio.sdk/twilio/${twilio-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-twilio/${project.version}</bundle>
     </feature>
     <feature name='camel-twitter' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.twitter4j/twitter4j-core/${twitter4j-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-twitter/${project.version}</bundle>
     </feature>
     <feature name='camel-undertow' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <bundle dependency='true'>mvn:io.undertow/undertow-core/${undertow-version}</bundle>
         <bundle dependency='true'>mvn:io.undertow/undertow-servlet/${undertow-version}</bundle>
@@ -2455,61 +2455,61 @@
         <bundle>mvn:org.apache.camel.karaf/camel-undertow/${project.version}</bundle>
     </feature>
     <feature name='camel-undertow-spring-security' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-undertow</feature>
-        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-undertow</feature>
+        <feature version='${camel-osgi-spring-version}'>spring</feature>
         <bundle dependency='true'>wrap:mvn:org.springframework.security/spring-security-core/${spring-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.springframework.security/spring-security-oauth2-jose/${spring-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.springframework.security/spring-security-oauth2-resource-server/${spring-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-undertow-spring-security/${project.version}</bundle>
     </feature>
     <feature name='camel-univocity-parsers' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:com.univocity/univocity-parsers/${univocity-parsers-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-univocity-parsers/${project.version}</bundle>
     </feature>
     <feature name='camel-vertx' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-vertx-common</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-vertx-common</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-vertx/${project.version}</bundle>
     </feature>
     <feature name='camel-vertx-common' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-vertx-common/${project.version}</bundle>
     </feature>
     <feature name='camel-vertx-http' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-vertx-common</feature>
+        <feature version='${camel-osgi-version-range}'>camel-vertx-common</feature>
         <bundle dependency='true'>mvn:org.apache.camel.karaf/camel-http-base/${project.version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web-client/${vertx-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web-common/${vertx-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-vertx-http/${project.version}</bundle>
     </feature>
     <feature name='camel-vertx-websocket' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-vertx-common</feature>
+        <feature version='${camel-osgi-version-range}'>camel-vertx-common</feature>
         <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web/${vertx-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-vertx-websocket/${project.version}</bundle>
     </feature>
     <feature name='camel-velocity' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-velocity/${project.version}</bundle>
     </feature>
     <feature name='camel-wal' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-wal/${project.version}</bundle>
     </feature>
     <feature name='camel-weather' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.httpcomponents.core5/httpcore5-h2/${httpclient-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-weather/${project.version}</bundle>
     </feature>
     <feature name='camel-web3j' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.web3j/core/${web3j-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.web3j/geth/${web3j-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.web3j/parity/${web3j-version}</bundle>
@@ -2519,49 +2519,49 @@
         <bundle>mvn:org.apache.camel.karaf/camel-web3j/${project.version}</bundle>
     </feature>
     <feature name='camel-webhook' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-webhook/${project.version}</bundle>
     </feature>
     <feature name='camel-whatsapp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.version.range}'>camel-webhook</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-webhook</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-whatsapp/${project.version}</bundle>
     </feature>
     <feature name='camel-wordpress' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-cxf</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-cxf</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${jackson2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-wordpress/${project.version}</bundle>
     </feature>
     <feature name='camel-workday' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[5,6)'>http-client</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-workday/${project.version}</bundle>
     </feature>
     <feature name='camel-xchange' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>wrap:mvn:org.knowm.xchange/xchange-core/${xchange-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.knowm.xchange/xchange-binance/${xchange-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.github.mmazi/rescu/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xchange/${project.version}</bundle>
     </feature>
     <feature name='camel-xj' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-xslt-saxon</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-xslt-saxon</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-xj/${project.version}</bundle>
     </feature>
     <feature name='camel-xmlsecurity' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.santuario/xmlsec/${xmlsec-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xmlsecurity/${project.version}</bundle>
     </feature>
     <feature name='camel-xmpp' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.igniterealtime.smack/smack-core/${smack-version}</bundle>
         <bundle dependency='true'>mvn:org.igniterealtime.smack/smack-extensions/${smack-version}</bundle>
         <bundle dependency='true'>mvn:org.igniterealtime.smack/smack-tcp/${smack-version}</bundle>
@@ -2574,18 +2574,18 @@
         <bundle>mvn:org.apache.camel.karaf/camel-xmpp/${project.version}</bundle>
     </feature>
     <feature name='camel-xslt-saxon' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:net.sf.saxon/Saxon-HE/${saxon-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xslt-saxon/${project.version}</bundle>
     </feature>
     <feature name='camel-yaml-dsl' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.snakeyaml/snakeyaml-engine/${snakeyaml-engine-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-yaml-dsl/${project.version}</bundle>
     </feature>
     <feature name='camel-zeebe' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-client-java/${zeebe.version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-gateway-protocol-impl/${zeebe.version}</bundle>
@@ -2593,7 +2593,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-zeebe/${project.version}</bundle>
     </feature>
     <feature name='camel-zendesk' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[4.1,5)'>netty</feature>
         <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client-netty-utils/${auto-detect-version}</bundle>
@@ -2606,18 +2606,18 @@
         <bundle>mvn:org.apache.camel.karaf/camel-zendesk/${project.version}</bundle>
     </feature>
     <feature name='camel-zip-deflater' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zip-deflater/${project.version}</bundle>
     </feature>
     <feature name='camel-zipfile' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-zipfile/${project.version}</bundle>
     </feature>
     <feature name='camel-zookeeper' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[32,33)">guava</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-version}$Export-Package=org.apache.zookeeper*;version=${zookeeper-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper-version}$Export-Package=org.apache.*;version=${zookeeper-version}</bundle>
@@ -2628,8 +2628,8 @@
         <bundle>mvn:org.apache.camel.karaf/camel-zookeeper/${project.version}</bundle>
     </feature>
     <feature name='camel-zookeeper-master' version='${project.version}' start-level='50'>
-        <feature version='${camel.osgi.version.range}'>camel-core</feature>
-        <feature version='${camel.osgi.jackson2.version}'>jackson</feature>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version="[32,33)">guava</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-version}$Export-Package=org.apache.zookeeper*;version=${zookeeper-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper-version}$Export-Package=org.apache.*;version=${zookeeper-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,9 @@
 
     <!-- TODO use Karaf/Camel bom -->
     <properties>
-        <jdk.version>17</jdk.version>
+        <jdk-version>17</jdk-version>
 
-        <aries.util.version>1.1.3</aries.util.version>
-        <aries.version>1.10.3</aries.version>
-        <camel.version>4.6.0</camel.version>
+        <camel-version>4.6.0</camel-version>
 
         <!-- START: Maven Properties defining the version of 3rd party libraries used in Camel -->
         <activemq-version>6.1.2</activemq-version>
@@ -515,52 +513,72 @@
         <zookeeper-version>3.9.2</zookeeper-version>
         <zxing-version>3.5.3</zxing-version>
         <!-- END: Maven Properties defining the version of 3rd party libraries used in Camel -->
-        <camel.osgi.asm.version>[9.5,10)</camel.osgi.asm.version>
-        <camel.osgi.spring.version>[6.1,6.2)</camel.osgi.spring.version>
-        <spring.amqp.version>3.1.5</spring.amqp.version>
-        <camel.osgi.slf4j.version>[2,3)</camel.osgi.slf4j.version>
-        <camel.osgi.jakarta.annotation.version>[2,3)</camel.osgi.jakarta.annotation.version>
-        <camel.osgi.jakarta.bind.version>[3,5)</camel.osgi.jakarta.bind.version>
-        <camel.osgi.jakarta.activation.version>[2,3)</camel.osgi.jakarta.activation.version>
-        <camel.osgi.jakarta.mail.version>[2,3)</camel.osgi.jakarta.mail.version>
-        <camel.osgi.jakarta.servlet.version>[5,7)</camel.osgi.jakarta.servlet.version>
-        <camel.osgi.jakarta.xml.ws.version>[3,5)</camel.osgi.jakarta.xml.ws.version>
-        <camel.osgi.jakarta.ws.rs.version>[3,4)</camel.osgi.jakarta.ws.rs.version>
-        <camel.cglib.osgi.version>[3.3,3.4)</camel.cglib.osgi.version>
-        <camel.osgi.cdi.version>[3,4)</camel.osgi.cdi.version>
-        <camel.osgi.jakarta.jwsapi.version>[3,4)</camel.osgi.jakarta.jwsapi.version>
-        <camel.osgi.saaj.version>[2,4)</camel.osgi.saaj.version>
-        <camel.opensaml.osgi.version>[4.2,5)</camel.opensaml.osgi.version>
-        <camel.ehcache.osgi.version>[3,4)</camel.ehcache.osgi.version>
-        <camel.jetty.osgi.version>[11,12)</camel.jetty.osgi.version>
-        <camel.osgi.netty.version>[4.1,5)</camel.osgi.netty.version>
-        <camel.undertow.xnio.osgi.version>[3.8,4)</camel.undertow.xnio.osgi.version>
-        <camel.undertow.osgi.version>[2.2,3)</camel.undertow.osgi.version>
-        <camel.osgi.jakarta.jms.version>[3.1,4)</camel.osgi.jakarta.jms.version>
-        <camel.osgi.jakarta.transaction.version>[2,3)</camel.osgi.jakarta.transaction.version>
-        <camel.validation.api.package.version>[2,4)</camel.validation.api.package.version>
-        <camel.osgi.cxf.version>[4.0,4.1)</camel.osgi.cxf.version>
-        <jakarta.xml.ws.version>4.0.2</jakarta.xml.ws.version>
-        <karaf.version>4.4.6</karaf.version>
-        <osgi.version>8.0.0</osgi.version>
-        <osgi.cmpn.version>7.0.0</osgi.cmpn.version>
-        <osgi.service.event.version>1.4.1</osgi.service.event.version>
-        <osgi.service.component.version>1.5.1</osgi.service.component.version>
-        <slf4j.version>2.0.13</slf4j.version>
-        <servicemix-specs-version>10</servicemix-specs-version> 
 
-        <camel.osgi.version.clean>4.6</camel.osgi.version.clean>
-        <camel.osgi.next.version.clean>4.7</camel.osgi.next.version.clean>
-        <camel.osgi.version.range>[${camel.osgi.version.clean},${camel.osgi.next.version.clean})</camel.osgi.version.range>
-        <camel.osgi.import.camel.version>version="${camel.osgi.version.range}"</camel.osgi.import.camel.version>
-        <camel.osgi.camel.import>org.apache.camel.*;${camel.osgi.import.camel.version},</camel.osgi.camel.import>
-        <camel.osgi.jackson2.version>[2.17,2.18)</camel.osgi.jackson2.version>
+        <!-- OSGI version ranges -->
+        <camel-osgi-asm-version>[9.5,10)</camel-osgi-asm-version>
+        <camel-osgi-cglib-version>[3.3,3.4)</camel-osgi-cglib-version>
+        <camel-osgi-jackson2-version>[2.17,2.18)</camel-osgi-jackson2-version>
+        <camel-osgi-jakarta-annotation-version>[2,3)</camel-osgi-jakarta-annotation-version>
+        <camel-osgi-jakarta-activation-version>[2.1,3)</camel-osgi-jakarta-activation-version>
+        <camel-osgi-jakarta-activation-runtime-version>[2,3)</camel-osgi-jakarta-activation-runtime-version>
+        <camel-osgi-jakarta-bind-version>[3,5)</camel-osgi-jakarta-bind-version>
+        <camel-osgi-jakarta-jws-version>[3,4)</camel-osgi-jakarta-jws-version>
+        <camel-osgi-jakarta-servlet-version>[5,7)</camel-osgi-jakarta-servlet-version>
+        <camel-osgi-jakarta-soap-version>[3,4)</camel-osgi-jakarta-soap-version>
+        <camel-osgi-jakarta-validation-version>[2,4)</camel-osgi-jakarta-validation-version>
+        <camel-osgi-jakarta-ws-rs-version>[3.1,4)</camel-osgi-jakarta-ws-rs-version>
+        <camel-osgi-jakarta-xml-ws-version>[4,5)</camel-osgi-jakarta-xml-ws-version>
+        <camel-osgi-jetty-version>[11,12)</camel-osgi-jetty-version>
+        <camel-osgi-spring-version>[6.1,6.2)</camel-osgi-spring-version>
+        <camel-osgi-saaj-version>[2,4)</camel-osgi-saaj-version>
+        <camel-osgi-slf4j-version>[2,3)</camel-osgi-slf4j-version>
+        <camel-osgi-cxf-version>[4.0,4.1)</camel-osgi-cxf-version>
 
+        <!-- Camel Karaf OSGI version ranges -->
+        <camel-osgi-version-clean>4.6</camel-osgi-version-clean>
+        <camel-osgi-next-version-clean>4.7</camel-osgi-next-version-clean>
+        <camel-osgi-version-range>[${camel-osgi-version-clean},${camel-osgi-next-version-clean})</camel-osgi-version-range>
+        <camel-osgi-import-camel-version>version="${camel-osgi-version-range}"</camel-osgi-import-camel-version>
+        <camel-osgi-camel-import>org.apache.camel.*;${camel-osgi-import-camel-version},</camel-osgi-camel-import>
+
+        <!-- Other dependencies version not inherited from Camel -->
+        <angus-activation-version>2.0.2</angus-activation-version>
+        <aries-util-version>1.1.3</aries-util-version>
+        <aries-version>1.10.3</aries-version>
+        <azure-core-version>1.48.0</azure-core-version>
+        <azure-identity-version>1.12.0</azure-identity-version>
+        <azure-messaging-eventhubs-checkpointstore-blob-version>1.19.3</azure-messaging-eventhubs-checkpointstore-blob-version>
+        <azure-messaging-eventhubs-version>5.18.3</azure-messaging-eventhubs-version>
+        <azure-storage-common-version>12.24.4</azure-storage-common-version>
+        <geronimo-atinject-version>1.2</geronimo-atinject-version>
+        <guava32-version>32.1.3-jre</guava32-version>
+        <harmcrest-version>1.3_1</harmcrest-version>
+        <httpclient4-version>4.5.14</httpclient4-version>
+        <httpcore4-version>4.4.16</httpcore4-version>
+        <jakarta-annotation2-api-version>2.1.1</jakarta-annotation2-api-version>
+        <jakarta-servlet5-api-version>5.0.0</jakarta-servlet5-api-version>
+        <jakarta-validation-api-version>3.0.2</jakarta-validation-api-version>
+        <jakarta-ws-rs-api-version>3.1.0</jakarta-ws-rs-api-version>
+        <jakarta-xml-bind3-api-version>3.0.1</jakarta-xml-bind3-api-version>
+        <jaxb3-core-version>3.0.2</jaxb3-core-version>
+        <jaxb3-impl-version>3.0.2</jaxb3-impl-version>
+        <jaxb3-osgi-version>3.0.2</jaxb3-osgi-version>
+        <jetty11-version>11.0.21</jetty11-version>
+        <karaf-version>4.4.6</karaf-version>
+        <netty-incubator-transport-classes-io_uring-version>0.0.25.Final</netty-incubator-transport-classes-io_uring-version>
+        <osgi-cmpn-version>7.0.0</osgi-cmpn-version>
+        <osgi-resource-locator-version>2.5.0-b42</osgi-resource-locator-version>
+        <osgi-service-event-version>1.4.1</osgi-service-event-version>
+        <osgi-service-component-version>1.5.1</osgi-service-component-version>
+        <osgi-version>8.0.0</osgi-version>
+        <servicemix-specs-version>10</servicemix-specs-version>
+        <slf4j-version>2.0.13</slf4j-version>
+        <spring-amqp-version>3.1.5</spring-amqp-version>
+
+        <!-- Plugin versions -->
         <maven-shade-plugin-version>3.6.0</maven-shade-plugin-version>
         <maven-bundle-plugin-version>5.1.9</maven-bundle-plugin-version>
         <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
-        <harmcrest.version>1.3_1</harmcrest.version>
-        <geronimo-atinject.version>1.2</geronimo-atinject.version>
     </properties>
 
     <dependencyManagement>
@@ -568,63 +586,63 @@
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.core</artifactId>
-                <version>${osgi.version}</version>
+                <version>${osgi-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.cmpn</artifactId>
-                <version>${osgi.cmpn.version}</version>
+                <version>${osgi-cmpn-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.event</artifactId>
-                <version>${osgi.service.event.version}</version>
+                <version>${osgi-service-event-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.component</artifactId>
-                <version>${osgi.service.component.version}</version>
+                <version>${osgi-service-component-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.component.annotations</artifactId>
-                <version>${osgi.service.component.version}</version>
+                <version>${osgi-service-component-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.shell</groupId>
                 <artifactId>org.apache.karaf.shell.core</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.aries.blueprint</groupId>
                 <artifactId>org.apache.aries.blueprint.core</artifactId>
-                <version>${aries.version}</version>
+                <version>${aries-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.aries</groupId>
                 <artifactId>org.apache.aries.util</artifactId>
-                <version>${aries.util.version}</version>
+                <version>${aries-util-version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.ws</groupId>
                 <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jakarta.xml.ws.version}</version>
+                <version>${jakarta-xml-ws-api-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
+                <version>${slf4j-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.servicemix.bundles</groupId>
                 <artifactId>org.apache.servicemix.bundles.hamcrest</artifactId>
-                <version>${harmcrest.version}</version>
+                <version>${harmcrest-version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-atinject_1.0_spec</artifactId>
-                <version>${geronimo-atinject.version}</version>
+                <version>${geronimo-atinject-version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -650,8 +668,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin-version}</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <source>${jdk-version}</source>
+                    <target>${jdk-version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -664,7 +682,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>${camel.osgi.export}</Export-Package>
-                        <Import-Package>${camel.osgi.camel.import}${camel.osgi.import}</Import-Package>
+                        <Import-Package>${camel-osgi-camel-import}${camel.osgi.import}</Import-Package>
                         <Private-Package>${camel.osgi.private}</Private-Package>
                         <DynamicImport-Package>${camel.osgi.dynamicimport.pkg}</DynamicImport-Package>
                         <Embed-Dependency>${camel.osgi.embed.dependency}</Embed-Dependency>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-services-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <executions>
                     <execution>
                         <id>service-metadata-generate</id>

--- a/tests/camel-integration-test/pom.xml
+++ b/tests/camel-integration-test/pom.xml
@@ -36,14 +36,14 @@
             <dependency>
                 <groupId>org.apache.karaf</groupId>
                 <artifactId>karaf-bom</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.itests</groupId>
                 <artifactId>common</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <scope>compile</scope>
             </dependency>
         </dependencies>
@@ -79,8 +79,8 @@
                             org.ops4j.pax.exam.options,
                             org.osgi.framework,
                             org.junit*,
-                            org.apache.camel.blueprint;resolution:=optional;${camel.osgi.import.camel.version},
-                            org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.apache.camel.blueprint;resolution:=optional;${camel-osgi-import-camel-version},
+                            org.apache.camel*;${camel-osgi-import-camel-version},
                             org.apache.karaf.features,
                             org.ops4j.pax.swissbox.tracker,
                             org.osgi.service.*,
@@ -145,13 +145,13 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-api</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-processor</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/camel-test-scr/pom.xml
+++ b/tests/camel-test-scr/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -81,10 +81,10 @@
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.apache.camel.karaf.test;version=${camel.version}
+                            org.apache.camel.karaf.test;version=${camel-version}
                         </Export-Package>
                         <Import-Package>
-                            org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.apache.camel*;${camel-osgi-import-camel-version},
                             *
                         </Import-Package>
                     </instructions>

--- a/tests/examples/pom.xml
+++ b/tests/examples/pom.xml
@@ -43,14 +43,14 @@
             <dependency>
                 <groupId>org.apache.karaf</groupId>
                 <artifactId>karaf-bom</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.itests</groupId>
                 <artifactId>common</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -181,7 +181,7 @@
                             org.apache.karaf.camel.examples.test;version=${project.version}
                         </Export-Package>
                         <Import-Package>
-                            org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.apache.camel*;${camel-osgi-import-camel-version},
                             *
                         </Import-Package>
                     </instructions>

--- a/tests/features/camel-ehcache/pom.xml
+++ b/tests/features/camel-ehcache/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-ehcache</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-elasticsearch/pom.xml
+++ b/tests/features/camel-elasticsearch/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-elasticsearch</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/tests/features/camel-hazelcast/pom.xml
+++ b/tests/features/camel-hazelcast/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-hazelcast</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/tests/features/camel-jcache/pom.xml
+++ b/tests/features/camel-jcache/pom.xml
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jcache</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-hazelcast</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/tests/features/camel-kafka/pom.xml
+++ b/tests/features/camel-kafka/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kafka</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -62,14 +62,14 @@
             <dependency>
                 <groupId>org.apache.karaf</groupId>
                 <artifactId>karaf-bom</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.itests</groupId>
                 <artifactId>common</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf-version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -91,13 +91,13 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
-            <version>${camel.version}</version>
+            <version>${camel-version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -200,7 +200,7 @@
                             org.apache.karaf.camel.test;version=${project.version}
                         </Export-Package>
                         <Import-Package>
-                            org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.apache.camel*;${camel-osgi-import-camel-version},
                             *
                         </Import-Package>
                     </instructions>

--- a/tooling/camel-karaf-feature-maven-plugin/pom.xml
+++ b/tooling/camel-karaf-feature-maven-plugin/pom.xml
@@ -29,15 +29,15 @@
     <name>Apache Camel :: Karaf :: Tooling :: Feature Maven Plugin</name>
 
     <properties>
-        <felix.utils.version>1.11.8</felix.utils.version>
-        <maven.version>3.9.7</maven.version>
+        <felix-utils-version>1.11.8</felix-utils-version>
+        <maven-version>3.9.7</maven-version>
     </properties>
     
     <dependencies>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>org.apache.karaf.features.core</artifactId>
-            <version>${karaf.version}</version>
+            <version>${karaf-version}</version>
         </dependency>
          
         <dependency>
@@ -47,20 +47,20 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.utils</artifactId>
-            <version>${felix.utils.version}</version>
+            <version>${felix-utils-version}</version>
         </dependency>
 
         <!-- maven plugin -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
+            <version>${maven-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
+            <version>${maven-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AutoDetectVersionMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/AutoDetectVersionMojo.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.karaf.features.internal.model.Bundle;
 import org.apache.karaf.features.internal.model.Feature;
@@ -238,7 +237,7 @@ public class AutoDetectVersionMojo extends AbstractFeaturesMojo {
                     .getArtifactResults()
                     .stream()
                     .map(ArtifactResult::getArtifact)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (Exception e) {
             getLog().warn("Dependencies of the artifact %s could not be resolved: %s".formatted(artifactId, e.getMessage()));
             if (getLog().isDebugEnabled()) {


### PR DESCRIPTION
fixes #350 

## Motivation

To ease migration and maintenance, we want to avoid having hard-coded versions in the file `camel-features.xml` 

## Modifications:

* Extract the remaining hard-coded versions in the parent pom file to have it centralized
* Use a consistent way for maven properties name where the dash is used as a separator
* Remove unused maven properties