### PR TITLE
Added missing camel-azure-storage-blob and integration test

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -182,10 +182,13 @@
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
     </feature>
     <feature name="azure" version="${azure-core-version}" start-level="50">
-        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/${azure-core-version}</bundle>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-core/${azure-core-version}$${spi-consumer}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-identity/${azure-identity-version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-xml/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.azure/azure-json/${auto-detect-version}</bundle>
     </feature>
     <feature name="azure-storage" version="${azure-core-version}" start-level="50">
         <feature version='[${azure-core-version},2)'>azure</feature>
@@ -560,10 +563,26 @@
         <bundle>mvn:org.apache.camel.karaf/camel-azure-servicebus/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-blob' version='${project.version}' start-level='50'>
+        <feature prerequisite="true">spifly</feature>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='[${azure-core-version},2)'>azure-storage</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.azure/azure-storage-blob-changefeed/${azure-storage-blob-changefeed-version}</bundle>
+        <bundle>wrap:mvn:com.azure/azure-core-http-netty/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-http/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-azure-storage-blob/${project.version}</bundle>
     </feature>
     <feature name='camel-azure-storage-datalake' version='${project.version}' start-level='50'>

--- a/tests/features/camel-azure-storage-blob/pom.xml
+++ b/tests/features/camel-azure-storage-blob/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-azure-storage-blob-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Azure Storage Blob</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-azure-storage-blob</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-azure-storage-blob/src/main/java/org/apache/karaf/camel/test/CamelAzureStorageBlobRouteSupplier.java
+++ b/tests/features/camel-azure-storage-blob/src/main/java/org/apache/karaf/camel/test/CamelAzureStorageBlobRouteSupplier.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.component.azure.storage.blob.BlobConstants.BLOB_CONTAINER_NAME;
+import static org.apache.camel.component.azure.storage.blob.BlobConstants.BLOB_NAME;
+import static org.apache.camel.component.azure.storage.blob.BlobConstants.BLOB_OPERATION;
+import static org.apache.camel.component.azure.storage.blob.CredentialType.SHARED_KEY_CREDENTIAL;
+
+import java.util.function.Function;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.azure.storage.blob.BlobComponent;
+import org.apache.camel.component.azure.storage.blob.BlobConfiguration;
+import org.apache.camel.component.azure.storage.blob.BlobOperationsDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+
+@Component(name = "karaf-camel-azure-storage-blob-test", immediate = true, service = CamelRouteSupplier.class)
+public class CamelAzureStorageBlobRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String TEST_BLOB_CONTAINER_NAME = "test-container";
+    private static final String TEST_BLOB_NAME = "hello.txt";
+
+    @Override
+    public void configure(CamelContext camelContext) {
+        final String accountName = System.getProperty("azure.accountName");
+        final String host = System.getProperty("azure.host");
+        final String port = System.getProperty("azure.port");
+        final StorageSharedKeyCredential credential =
+                new StorageSharedKeyCredential(accountName, System.getProperty("azure.accountKey"));
+        final String endpoint = "http://" + host + ":" + port + "/" + accountName;
+
+        final BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().endpoint(endpoint)
+                .credential(credential)
+                .httpLogOptions(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS).setPrettyPrintBody(true))
+                .buildClient();
+
+        final BlobConfiguration configuration = new BlobConfiguration();
+        configuration.setServiceClient(blobServiceClient);
+        configuration.setAccountName(accountName);
+        configuration.setCredentials(credential);
+        configuration.setCredentialType(SHARED_KEY_CREDENTIAL);
+
+        final BlobComponent blobComponent = new BlobComponent();
+        blobComponent.setConfiguration(configuration);
+
+        camelContext.addComponent("azure-storage-blob", blobComponent);
+    }
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder -> builder.from("azure-storage-blob://devstoreaccount1/" + TEST_BLOB_CONTAINER_NAME + "?blobName=" + TEST_BLOB_NAME)
+                .setHeader(BLOB_CONTAINER_NAME, builder.constant(TEST_BLOB_CONTAINER_NAME))
+                .setHeader(BLOB_NAME, builder.constant(TEST_BLOB_NAME))
+                .log("Downloaded the blob with content: ${body}")
+                .setBody(builder.constant("OK"));
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute.setHeader(BLOB_OPERATION, builder.constant(BlobOperationsDefinition.createBlobContainer.name()))
+                .setHeader(BLOB_CONTAINER_NAME, builder.constant(TEST_BLOB_CONTAINER_NAME))
+                .toF("azure-storage-blob://devstoreaccount1")
+                .log("Created container successful: ${body}")
+                .setHeader(BLOB_OPERATION, builder.constant(BlobOperationsDefinition.uploadBlockBlob.name()))
+                .setHeader(BLOB_NAME, builder.constant(TEST_BLOB_NAME))
+                .setBody(builder.constant("This is the blob!"))
+                .toF("azure-storage-blob://devstoreaccount1")
+                .log("Uploaded blob successful: ${body}");
+    }
+}

--- a/tests/features/camel-azure-storage-blob/src/test/java/org/apache/karaf/camel/itest/CamelAzureStorageBlobITest.java
+++ b/tests/features/camel-azure-storage-blob/src/test/java/org/apache/karaf/camel/itest/CamelAzureStorageBlobITest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+@CamelKarafTestHint(externalResourceProvider = CamelAzureStorageBlobITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelAzureStorageBlobITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    private static final int AZURITE_ORIGINAL_PORT = 10000;
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+        private static final String DEFAULT_ACCOUNT_NAME = "devstoreaccount1";
+        private static final String DEFAULT_ACCOUNT_KEY
+                = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+        public static GenericContainerResource<AzuriteContainer> createAzureStorageBlobContainer() {
+
+            AzuriteContainer azuriteContainer = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.29.0");
+
+            return new GenericContainerResource<>(azuriteContainer, resource -> {
+                resource.setProperty("azure.host", azuriteContainer.getHost());
+                resource.setProperty("azure.port",
+                        Integer.toString(azuriteContainer.getMappedPort(AZURITE_ORIGINAL_PORT)));
+                resource.setProperty("azure.accountName", DEFAULT_ACCOUNT_NAME);
+                resource.setProperty("azure.accountKey", DEFAULT_ACCOUNT_KEY);
+            });
+        }
+    }
+
+    public static class AzuriteContainer extends GenericContainer<AzuriteContainer> {
+
+        public AzuriteContainer(final String containerName) {
+            super(containerName);
+
+            withExposedPorts(AZURITE_ORIGINAL_PORT)
+                    .waitingFor(Wait.forListeningPort());
+        }
+
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -42,6 +42,7 @@
         <module>camel-aws2-ses</module>
         <module>camel-aws2-sns</module>
         <module>camel-aws2-sqs</module>
+        <module>camel-azure-storage-blob</module>
         <module>camel-core</module>
         <module>camel-ehcache</module>
         <module>camel-elasticsearch</module>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/362
Motivation
During testing using an OSGI blueprint, it turned out that the camel-azure-storage-blob is missing bundles to successfully execute the route.

Modifications:
Add the missing bundles with appropriate SPI-consumer statements