### PR TITLE
Added camel-jms integration test

### DIFF
--- a/tests/features/camel-jms/pom.xml
+++ b/tests/features/camel-jms/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-jms-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: JMS</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>activemq</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/features/camel-jms/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-jms/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -48,9 +48,6 @@
         <route id="activeMqConsumerRoute">
             <from uri="jms:queue:jmsQueueName"/>
             <log message="Message received from JMS: ${body}"/>
-            <setBody>
-                <constant>OK</constant>
-            </setBody>
             <to uri="mock:camel-jms-test"/>
         </route>
     </camelContext>

--- a/tests/features/camel-jms/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-jms/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+    <!-- Allow the use of system properties -->
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
+
+    <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+        <argument value="tcp://$[jms.host]:$[jms.port]"/>
+        <property name="userName" value="$[jms.username]"/>
+        <property name="password" value="$[jms.password]"/>
+    </bean>
+
+    <bean id="jms" class="org.apache.camel.component.jms.JmsComponent">
+        <property name="connectionFactory" ref="connectionFactory"/>
+    </bean>
+
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/blueprint">
+        <route id="activeMqProducerRoute">
+            <from uri="direct:camel-jms-test"/>
+            <setBody>
+                <simple>Hello Camel</simple>
+            </setBody>
+            <log message="Sending message to JMS: ${body}"/>
+            <to uri="jms:queue:jmsQueueName"/>
+            <log message="Message sent to JMS: ${body}"/>
+        </route>
+        <route id="activeMqConsumerRoute">
+            <from uri="jms:queue:jmsQueueName"/>
+            <log message="Message received from JMS: ${body}"/>
+            <setBody>
+                <constant>OK</constant>
+            </setBody>
+            <to uri="mock:camel-jms-test"/>
+        </route>
+    </camelContext>
+
+</blueprint>

--- a/tests/features/camel-jms/src/test/java/org/apache/karaf/camel/itest/CamelJmsITest.java
+++ b/tests/features/camel-jms/src/test/java/org/apache/karaf/camel/itest/CamelJmsITest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.activemq.ActiveMQContainer;
+
+@CamelKarafTestHint(
+        externalResourceProvider = CamelJmsITest.ExternalResourceProviders.class,
+        isBlueprintTest = true,
+        additionalRequiredFeatures = "camel-activemq" // Needed for the client implementation
+)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelJmsITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+        
+        public static final String ACTIVEMQ_USER = "myUser";
+        public static final String ACTIVEMQ_PASSWORD = "myPassword";
+        public static final int ACTIVEMQ_ORIGINAL_PORT = 61616;
+
+        public static GenericContainerResource<ActiveMQContainer> createActiveMQContainer() {
+
+            ActiveMQContainer activemqContainer = new ActiveMQContainer("apache/activemq-classic:6.1.0")
+                    .withUser(ACTIVEMQ_USER)
+                    .withPassword(ACTIVEMQ_PASSWORD);
+
+            return new GenericContainerResource<>(activemqContainer,
+                    resource -> {
+                        resource.setProperty("jms.host", activemqContainer.getHost());
+                        resource.setProperty("jms.port", Integer.toString(activemqContainer.getMappedPort(ACTIVEMQ_ORIGINAL_PORT)));
+                        resource.setProperty("jms.username", ACTIVEMQ_USER);
+                        resource.setProperty("jms.password", ACTIVEMQ_PASSWORD);
+                    }
+            );
+        }
+    }
+}

--- a/tests/features/camel-jms/src/test/java/org/apache/karaf/camel/itest/CamelJmsITest.java
+++ b/tests/features/camel-jms/src/test/java/org/apache/karaf/camel/itest/CamelJmsITest.java
@@ -35,7 +35,7 @@ public class CamelJmsITest extends AbstractCamelSingleFeatureResultMockBasedRout
 
     @Override
     public void configureMock(MockEndpoint mock) {
-        mock.expectedBodiesReceived("OK");
+        mock.expectedBodiesReceived("Hello Camel");
     }
 
     @Test

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -49,6 +49,7 @@
         <module>camel-http</module>
         <module>camel-jcache</module>
         <module>camel-jetty</module>
+        <module>camel-jms</module>
         <module>camel-kafka</module>
         <module>camel-netty-http</module>
         <module>camel-mail</module>


### PR DESCRIPTION
Fixes #368 
Added `camel-activemq` feature to use the jakarta JMS client, the JMS component is used in the test