### PR TITLE
Add camel-arangodb integration test and fix feature

### DIFF
--- a/components/camel-arangodb/pom.xml
+++ b/components/camel-arangodb/pom.xml
@@ -37,44 +37,8 @@
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
-            !com.arangodb*,
-            !com.fasterxml.jackson*,
-            !io.netty*,
-            !com.aayushatharva.brotli4j*,
-            !com.github.luben*,
-            !com.google.protobuf*,
-            !com.jcraft.jzlib,
-            !com.ning.compress*,
-            !io.vertx*,
-            !lzma.sdk*,
-            !net.jpountz*,
-            !org.bouncycastle*,
-            !org.conscrypt*,
-            !org.eclipse.jetty*,
-            !org.jboss.marshalling*,
-            com.oracle*;resolution:=optional,
-            java.nio*;resolution:=optional,
-            reactor*;resolution:=optional,
-            sun*;resolution:=optional,
             *
         </camel.osgi.import>
-        <camel.osgi.private>
-            com.arangodb*,
-            com.fasterxml.jackson*,
-            io.netty*,
-            com.aayushatharva.brotli4j*,
-            com.github.luben*,
-            com.google.protobuf*,
-            com.jcraft.jzlib,
-            com.ning.compress*,
-            io.vertx*,
-            lzma.sdk*,
-            net.jpountz*,
-            org.bouncycastle*,
-            org.conscrypt*,
-            org.eclipse.jetty*,
-            org.jboss.marshalling*
-        </camel.osgi.private>
     </properties>
 
     <dependencies>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -92,8 +92,14 @@
 
     <feature name="jackson" version="${jackson2-version}">
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}$overwrite=merge</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
+    </feature>
+
+    <feature name="jackson" version="2.16.2">
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/2.16.2</bundle>
+        <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/2.16.2$overwrite=merge</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/2.16.2</bundle>
     </feature>
 
     <feature name="jetty" version="${jetty11-version}">
@@ -315,6 +321,20 @@
 
     <feature name='camel-arangodb' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='[2.16,2.17)'>jackson</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle>wrap:mvn:com.arangodb/core/${auto-detect-version}$${spi-consumer}</bundle>
+        <bundle>wrap:mvn:com.arangodb/http-protocol/${auto-detect-version}</bundle>
+        <bundle>wrap:mvn:com.arangodb/jackson-serde-json/${auto-detect-version}$${spi-consumer}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web-client/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web-common/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-uri-template/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-auth-common/${vertx-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-arangodb/${project.version}</bundle>
     </feature>
     <feature name='camel-as2' version='${project.version}' start-level='50'>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -92,14 +92,16 @@
 
     <feature name="jackson" version="${jackson2-version}">
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
+        <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
         <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}$overwrite=merge</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
     </feature>
 
-    <feature name="jackson" version="2.16.2">
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/2.16.2</bundle>
-        <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/2.16.2$overwrite=merge</bundle>
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/2.16.2</bundle>
+    <feature name="jackson" version="${jackson216-version}">
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson216-version}</bundle>
+        <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
+        <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/${jackson216-version}$overwrite=merge</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson216-version}</bundle>
     </feature>
 
     <feature name="jetty" version="${jetty11-version}">

--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,7 @@
         <harmcrest-version>1.3_1</harmcrest-version>
         <httpclient4-version>4.5.14</httpclient4-version>
         <httpcore4-version>4.4.16</httpcore4-version>
+        <jackson216-version>2.16.2</jackson216-version>
         <jakarta-annotation2-api-version>2.1.1</jakarta-annotation2-api-version>
         <jakarta-servlet5-api-version>5.0.0</jakarta-servlet5-api-version>
         <jakarta-validation-api-version>3.0.2</jakarta-validation-api-version>

--- a/tests/features/camel-arangodb/pom.xml
+++ b/tests/features/camel-arangodb/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-arangodb-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Arango DB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-arangodb</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/tests/features/camel-arangodb/src/main/java/org/apache/karaf/camel/test/CamelArangodbRouteSupplier.java
+++ b/tests/features/camel-arangodb/src/main/java/org/apache/karaf/camel/test/CamelArangodbRouteSupplier.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.builder.Builder.constant;
+import static org.apache.camel.component.arangodb.ArangoDbConstants.AQL_QUERY;
+import static org.apache.camel.component.arangodb.ArangoDbConstants.ARANGO_KEY;
+import static org.apache.camel.component.arangodb.ArangoDbConstants.RESULT_CLASS_TYPE;
+
+import java.util.List;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.arangodb.ArangoDbComponent;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import com.arangodb.ArangoDB;
+import com.arangodb.ArangoDatabase;
+import com.arangodb.entity.BaseDocument;
+
+@Component(name = "karaf-camel-arangodb-test", immediate = true, service = CamelRouteSupplier.class)
+public class CamelArangodbRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String DATABASE_NAME = "testdb";
+    private static final String COLLECTION_NAME = "testcol";
+
+    @Override
+    public void configure(CamelContext camelContext) {
+        final int arangoPort = Integer.parseInt(System.getProperty("arango.port"));
+        ArangoDB arangoDb = new ArangoDB.Builder().host("localhost", arangoPort).build();
+
+        arangoDb.createDatabase(DATABASE_NAME);
+        ArangoDatabase arangoDatabase = arangoDb.db(DATABASE_NAME);
+        arangoDatabase.createCollection(COLLECTION_NAME);
+
+        ArangoDbComponent arangoDbComponent = new ArangoDbComponent();
+        arangoDbComponent.setArangoDB(arangoDb);
+        arangoDbComponent.getConfiguration().setHost("localhost");
+        arangoDbComponent.getConfiguration().setPort(arangoPort);
+
+        camelContext.addComponent("arangodb",arangoDbComponent);
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+
+        BaseDocument myObject0 = new BaseDocument();
+        myObject0.setKey("key0");
+        myObject0.addAttribute("c", 42);
+
+
+        BaseDocument myObject = new BaseDocument();
+        myObject.setKey("key1");
+        myObject.addAttribute("a", "OK for later");
+        myObject.addAttribute("b", 42);
+
+        BaseDocument myUpdatedObject = new BaseDocument();
+        myUpdatedObject.setKey("key1");
+        myUpdatedObject.addAttribute("a", "OK for later");
+        myUpdatedObject.updateAttribute("a","OK");
+
+
+        //to add the mock endpoint at the end of the route, call configureConsumer
+        configureConsumer(
+            producerRoute
+                    //insert
+                    .log("insert 2 documents")
+                    .setBody(builder.constant(myObject0))
+                    .toF("arangodb:%s?documentCollection=%s&operation=SAVE_DOCUMENT", DATABASE_NAME, COLLECTION_NAME)
+                    .setBody(builder.constant(myObject))
+                    .toF("arangodb:%s?documentCollection=%s&operation=SAVE_DOCUMENT", DATABASE_NAME, COLLECTION_NAME)
+                    //update
+                    .log("update document key")
+                    .setBody(constant(myUpdatedObject))
+                    .setHeader(ARANGO_KEY,constant("key1"))
+                    .toF("arangodb:%s?documentCollection=%s&operation=UPDATE_DOCUMENT", DATABASE_NAME, COLLECTION_NAME)
+                    //delete
+                    .log("delete document key0")
+                    .setBody(constant("key0"))
+                    .toF("arangodb:%s?documentCollection=%s&operation=DELETE_DOCUMENT", DATABASE_NAME, COLLECTION_NAME)
+                    //query
+                    .setHeader(AQL_QUERY,constant("FOR doc IN %s RETURN doc".formatted(COLLECTION_NAME)))
+                    .setHeader(RESULT_CLASS_TYPE, constant(BaseDocument.class))
+                    .toF("arangodb:%s?operation=AQL_QUERY", DATABASE_NAME, COLLECTION_NAME)
+                    .log("after query ${body}")
+                    .process( exchange ->
+                            exchange.getIn().setBody(
+                                            ((BaseDocument) exchange.getIn().getMandatoryBody(List.class).get(0)).getAttribute("a")))
+                    .log("end: ${body}")
+        );
+
+    }
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+}

--- a/tests/features/camel-arangodb/src/test/java/org/apache/karaf/camel/itest/CamelArangodbITest.java
+++ b/tests/features/camel-arangodb/src/test/java/org/apache/karaf/camel/itest/CamelArangodbITest.java
@@ -33,7 +33,6 @@ public class CamelArangodbITest extends AbstractCamelSingleFeatureResultMockBase
 
     public static final Integer PORT_DEFAULT = 8529;
 
-
     @Override
     public void configureMock(MockEndpoint mock) {
         mock.expectedBodiesReceived("OK");

--- a/tests/features/camel-arangodb/src/test/java/org/apache/karaf/camel/itest/CamelArangodbITest.java
+++ b/tests/features/camel-arangodb/src/test/java/org/apache/karaf/camel/itest/CamelArangodbITest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import java.util.function.Consumer;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.GenericContainer;
+
+@CamelKarafTestHint(externalResourceProvider = CamelArangodbITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelArangodbITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    public static final Integer PORT_DEFAULT = 8529;
+
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+
+    public static final class ExternalResourceProviders {
+
+        public static GenericContainerResource createArangoContainer() {
+            final GenericContainer<?> arangoContainer =
+                    new GenericContainer<>("arangodb/arangodb:3.11.5")
+                            .withExposedPorts(PORT_DEFAULT)
+                            .withEnv("ARANGO_NO_AUTH", "1");
+
+            return new GenericContainerResource(arangoContainer, (Consumer<GenericContainerResource>) resource -> {
+                resource.setProperty("arango.port", Integer.toString(arangoContainer.getMappedPort(PORT_DEFAULT)));
+            });
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -39,6 +39,7 @@
     <modules>
         <module>camel-activemq</module>
         <module>camel-amqp</module>
+        <module>camel-arangodb</module>
         <module>camel-aws2-ses</module>
         <module>camel-aws2-sns</module>
         <module>camel-aws2-sqs</module>


### PR DESCRIPTION
fixes #376 
- uses wrap instead of private packages
- add a 2.16.2 jackson feature to avoid warning in logs about unsupported version of jackson
- add a wrap around `jackson-core` to add the SPI-Provider