### PR TITLE
Ref #375: Add missing components of Camel 4.6

### DIFF
--- a/components/camel-ai/camel-chatscript/pom.xml
+++ b/components/camel-ai/camel-chatscript/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-ai-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-chatscript</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Ai :: ChatScript</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-chatscript</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-chatscript</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-ai/camel-djl/pom.xml
+++ b/components/camel-ai/camel-djl/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-ai-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-djl</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Ai :: Deep Java Library</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-djl</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-djl</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-ai/camel-langchain4j-chat/pom.xml
+++ b/components/camel-ai/camel-langchain4j-chat/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-ai-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-langchain4j-chat</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Ai :: Langchain4j Chat</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-langchain4j-chat</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-langchain4j-chat</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-ai/camel-langchain4j-embeddings/pom.xml
+++ b/components/camel-ai/camel-langchain4j-embeddings/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-ai-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-langchain4j-embeddings</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Ai :: Langchain4j Embeddings</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-langchain4j-embeddings</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-langchain4j-embeddings</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-ai/pom.xml
+++ b/components/camel-ai/pom.xml
@@ -28,21 +28,14 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-ai-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Ai :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-chatscript</module>
+        <module>camel-djl</module>
+        <module>camel-langchain4j-chat</module>
+        <module>camel-langchain4j-embeddings</module>
     </modules>
 </project>
-

--- a/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-avro-rpc-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-avro-rpc-jetty</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Avro Rpc :: Avro Rpc Jetty</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-avro-rpc-jetty</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-avro-rpc-jetty</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-avro-rpc/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-avro-rpc-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-avro-rpc</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Avro Rpc :: Avro Rpc</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-avro-rpc</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-avro-rpc-spi</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-avro-rpc</include>
+                                    <include>org.apache.camel:camel-avro-rpc-spi</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/pom.xml
@@ -28,21 +28,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-avro-rpc-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Avro Rpc :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-avro-rpc</module>
+        <module>camel-avro-rpc-jetty</module>
     </modules>
 </project>
-

--- a/components/camel-aws/camel-aws-bedrock/pom.xml
+++ b/components/camel-aws/camel-aws-bedrock/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-aws-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-aws-bedrock</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Aws :: Aws Bedrock</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws-bedrock</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-aws-bedrock</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -33,6 +33,7 @@
     <name>Apache Camel :: Karaf :: Components :: AWS :: Parent</name>
 
     <modules>
+        <module>camel-aws-bedrock</module>
         <module>camel-aws-cloudtrail</module>
         <module>camel-aws-config</module>
         <module>camel-aws-secrets-manager</module>

--- a/components/camel-beanio/pom.xml
+++ b/components/camel-beanio/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-beanio</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: BeanIO</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-beanio</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-beanio</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-common/pom.xml
+++ b/components/camel-debezium/camel-debezium-common/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-common</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Common</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-db2/pom.xml
+++ b/components/camel-debezium/camel-debezium-db2/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-db2</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Db2</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-db2</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-db2</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-mongodb/pom.xml
+++ b/components/camel-debezium/camel-debezium-mongodb/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-mongodb</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Mongodb</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-mongodb</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-mongodb</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-mysql</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Mysql</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-mysql</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-mysql</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-oracle</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Oracle</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-oracle</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-oracle</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-postgres/pom.xml
+++ b/components/camel-debezium/camel-debezium-postgres/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-debezium-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-debezium-postgres</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Postgres</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-postgres</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-debezium-postgres</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-debezium/camel-debezium-sqlserver/pom.xml
+++ b/components/camel-debezium/camel-debezium-sqlserver/pom.xml
@@ -23,14 +23,14 @@
 
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
-        <artifactId>camel-karaf-components</artifactId>
+        <artifactId>camel-debezium-parent</artifactId>
         <version>4.6.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-djl</artifactId>
+    <artifactId>camel-debezium-sqlserver</artifactId>
     <packaging>bundle</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Deep Java Library</name>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Debezium Sqlserver</name>
 
     <properties>
         <camel.osgi.export>
@@ -44,7 +44,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-djl</artifactId>
+            <artifactId>camel-debezium-sqlserver</artifactId>
             <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
@@ -69,7 +69,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>org.apache.camel:camel-djl</include>
+                                    <include>org.apache.camel:camel-debezium-sqlserver</include>
                                 </includes>
                             </artifactSet>
                         </configuration>
@@ -79,4 +79,3 @@
         </plugins>
     </build>
 </project>
-

--- a/components/camel-debezium/pom.xml
+++ b/components/camel-debezium/pom.xml
@@ -28,21 +28,17 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-debezium-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Debezium :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-debezium-common</module>
+        <module>camel-debezium-db2</module>
+        <module>camel-debezium-mongodb</module>
+        <module>camel-debezium-mysql</module>
+        <module>camel-debezium-oracle</module>
+        <module>camel-debezium-postgres</module>
+        <module>camel-debezium-sqlserver</module>
     </modules>
 </project>
-

--- a/components/camel-dhis2/pom.xml
+++ b/components/camel-dhis2/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-dhis2</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: DHIS2</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-dhis2</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-dhis2-api</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-dhis2</include>
+                                    <include>org.apache.camel:camel-dhis2-api</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-fhir/pom.xml
+++ b/components/camel-fhir/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-fhir</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: FHIR</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-fhir</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-fhir-api</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-fhir</include>
+                                    <include>org.apache.camel:camel-fhir-api</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-google/camel-google-pubsub-lite/pom.xml
+++ b/components/camel-google/camel-google-pubsub-lite/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-google-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-google-pubsub-lite</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Google :: Google Pubsub Lite</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel-osgi-camel-import>
+            org.apache.camel.component.cloudevents*;${camel-osgi-import-camel-version};resolution:=optional,
+            org.apache.camel*;${camel-osgi-import-camel-version},
+        </camel-osgi-camel-import>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-google-pubsub-lite</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-google-pubsub-lite</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-common/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-common/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-common</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Common</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-dms/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-dms/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-dms</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Dms</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-dms</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-dms</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-frs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-frs/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-frs</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Frs</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-frs</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-frs</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-functiongraph</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Functiongraph</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-functiongraph</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-functiongraph</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-iam/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-iam/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-iam</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Iam</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-iam</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-iam</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-imagerecognition</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Imagerecognition</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-imagerecognition</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-imagerecognition</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-obs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-obs/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-obs</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Obs</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-obs</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-obs</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/camel-huaweicloud-smn/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-smn/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-huawei-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-huaweicloud-smn</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Huaweicloud Smn</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-huaweicloud-smn</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-huaweicloud-smn</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-huawei/pom.xml
+++ b/components/camel-huawei/pom.xml
@@ -28,21 +28,18 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-huawei-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Huawei :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-huaweicloud-common</module>
+        <module>camel-huaweicloud-dms</module>
+        <module>camel-huaweicloud-frs</module>
+        <module>camel-huaweicloud-functiongraph</module>
+        <module>camel-huaweicloud-iam</module>
+        <module>camel-huaweicloud-imagerecognition</module>
+        <module>camel-huaweicloud-obs</module>
+        <module>camel-huaweicloud-smn</module>
     </modules>
 </project>
-

--- a/components/camel-infinispan/camel-infinispan-common/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-common/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-infinispan-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-infinispan-common</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Infinispan :: Infinispan Common</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-infinispan-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-infinispan-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-infinispan/camel-infinispan-embedded/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-embedded/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-infinispan-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-infinispan-embedded</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Infinispan :: Infinispan Embedded</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-infinispan-embedded</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-infinispan-embedded</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-infinispan/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/camel-infinispan/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-infinispan-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-infinispan</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Infinispan :: Infinispan</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            org.infinispan.protostream*;resolution:=optional,
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-infinispan</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-infinispan</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -28,21 +28,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-infinispan-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Infinispan :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-infinispan</module>
+        <module>camel-infinispan-common</module>
+        <module>camel-infinispan-embedded</module>
     </modules>
 </project>
-

--- a/components/camel-knative/camel-knative-http/pom.xml
+++ b/components/camel-knative/camel-knative-http/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-knative-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-knative-http</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Knative :: Knative Http</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-knative-http</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-knative-http</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-knative/camel-knative/pom.xml
+++ b/components/camel-knative/camel-knative/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-knative-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-knative</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Knative :: Knative</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-knative</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-knative-api</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-knative</include>
+                                    <include>org.apache.camel:camel-knative-api</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-knative/pom.xml
+++ b/components/camel-knative/pom.xml
@@ -28,21 +28,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-knative-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Knative :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-knative</module>
+        <module>camel-knative-http</module>
     </modules>
 </project>
-

--- a/components/camel-microprofile/camel-microprofile-config/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-config/pom.xml
@@ -23,14 +23,14 @@
 
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
-        <artifactId>camel-karaf-components</artifactId>
+        <artifactId>camel-microprofile-parent</artifactId>
         <version>4.6.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-chatscript</artifactId>
+    <artifactId>camel-microprofile-config</artifactId>
     <packaging>bundle</packaging>
-    <name>Apache Camel :: Karaf :: Components :: ChatScript</name>
+    <name>Apache Camel :: Karaf :: Components :: Microprofile :: Microprofile Config</name>
 
     <properties>
         <camel.osgi.export>
@@ -44,7 +44,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-chatscript</artifactId>
+            <artifactId>camel-microprofile-config</artifactId>
             <version>${camel-version}</version>
             <exclusions>
                 <exclusion>
@@ -69,7 +69,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>org.apache.camel:camel-chatscript</include>
+                                    <include>org.apache.camel:camel-microprofile-config</include>
                                 </includes>
                             </artifactSet>
                         </configuration>
@@ -79,4 +79,3 @@
         </plugins>
     </build>
 </project>
-

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-microprofile-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-microprofile-fault-tolerance</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Microprofile :: Microprofile Fault Tolerance</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-microprofile-fault-tolerance</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-microprofile-fault-tolerance</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-microprofile/camel-microprofile-health/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-health/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-microprofile-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-microprofile-health</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Microprofile :: Microprofile Health</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-microprofile-health</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-microprofile-health</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-microprofile/pom.xml
+++ b/components/camel-microprofile/pom.xml
@@ -28,21 +28,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-google-parent</artifactId>
+    <artifactId>camel-microprofile-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Apache Camel :: Karaf :: Components :: Google : Parent</name>
+    <name>Apache Camel :: Karaf :: Components :: Microprofile :: Parent</name>
 
     <modules>
-        <module>camel-google-bigquery</module>
-        <module>camel-google-calendar</module>
-        <module>camel-google-drive</module>
-        <module>camel-google-functions</module>
-        <module>camel-google-mail</module>
-        <module>camel-google-pubsub</module>
-        <module>camel-google-pubsub-lite</module>
-        <module>camel-google-secret-manager</module>
-        <module>camel-google-sheets</module>
-        <module>camel-google-storage</module>
+        <module>camel-microprofile-config</module>
+        <module>camel-microprofile-fault-tolerance</module>
+        <module>camel-microprofile-health</module>
     </modules>
 </project>
-

--- a/components/camel-milvus/pom.xml
+++ b/components/camel-milvus/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-milvus</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Milvus</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-milvus</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-milvus</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-pinecone/pom.xml
+++ b/components/camel-pinecone/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-pinecone</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Pinecone</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-pinecone</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-pinecone</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-platform-http-jolokia/pom.xml
+++ b/components/camel-platform-http-jolokia/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-platform-http-jolokia</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Jolokia</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-platform-http-jolokia</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-platform-http-jolokia</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-qdrant/pom.xml
+++ b/components/camel-qdrant/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-qdrant</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Qdrant</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-qdrant</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-qdrant</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/camel-wasm/pom.xml
+++ b/components/camel-wasm/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-wasm</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache Camel :: Karaf :: Components :: Wasm</name>
+
+    <properties>
+        <camel.osgi.export>
+            org.apache.camel*;version=${camel-version}
+        </camel.osgi.export>
+        <camel.osgi.import>
+            *
+        </camel.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-wasm</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.camel:camel-wasm</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -34,6 +34,7 @@
 
     <modules>
         <module>camel-activemq</module>
+        <module>camel-ai</module>
         <module>camel-amqp</module>
         <module>camel-arangodb</module>
         <module>camel-as2</module>
@@ -43,12 +44,14 @@
         <module>camel-atom</module>
         <module>camel-attachments</module>
         <module>camel-avro</module>
+        <module>camel-avro-rpc</module>
         <module>camel-aws</module>
         <module>camel-azure</module>
         <module>camel-barcode</module>
         <module>camel-base64</module>
         <module>camel-bean</module>
         <module>camel-bean-validator</module>
+        <module>camel-beanio</module>
         <module>camel-bindy</module>
         <module>camel-blueprint</module>
         <module>camel-bonita</module>
@@ -58,7 +61,6 @@
         <module>camel-caffeine</module>
         <module>camel-cassandraql</module>
         <module>camel-cbor</module>
-        <module>camel-chatscript</module>
         <module>camel-chunk</module>
         <module>camel-cloudevents</module>
         <module>camel-cm-sms</module>
@@ -76,12 +78,13 @@
         <module>camel-dataformat</module>
         <module>camel-dataset</module>
         <module>camel-datasonnet</module>
+        <module>camel-debezium</module>
         <module>camel-debug</module>
+        <module>camel-dhis2</module>
         <module>camel-digitalocean</module>
         <module>camel-direct</module>
         <module>camel-directvm</module>
         <module>camel-disruptor</module>
-        <module>camel-djl</module>
         <module>camel-dns</module>
         <module>camel-docker</module>
         <module>camel-drill</module>
@@ -94,6 +97,7 @@
         <module>camel-etcd3</module>
         <module>camel-exec</module>
         <module>camel-fastjson</module>
+        <module>camel-fhir</module>
         <module>camel-file</module>
         <module>camel-file-watch</module>
         <module>camel-flatpack</module>
@@ -119,9 +123,11 @@
         <module>camel-http</module>
         <module>camel-http-base</module>
         <module>camel-http-common</module>
+        <module>camel-huawei</module>
         <module>camel-ical</module>
         <module>camel-iec60870</module>
         <module>camel-ignite</module>
+        <module>camel-infinispan</module>
         <module>camel-influxdb</module>
         <module>camel-influxdb2</module>
         <module>camel-irc</module>
@@ -162,6 +168,7 @@
         <module>camel-jte</module>
         <module>camel-kafka</module>
         <module>camel-kamelet</module>
+        <module>camel-knative</module>
         <module>camel-kubernetes</module>
         <module>camel-kudu</module>
         <module>camel-language</module>
@@ -180,6 +187,8 @@
         <module>camel-metrics</module>
         <module>camel-micrometer</module>
         <module>camel-micrometer-prometheus</module>
+        <module>camel-microprofile</module>
+        <module>camel-milvus</module>
         <module>camel-mina</module>
         <module>camel-minio</module>
         <module>camel-mllp</module>
@@ -209,7 +218,9 @@
         <module>camel-pdf</module>
         <module>camel-pg-replication-slot</module>
         <module>camel-pgevent</module>
+        <module>camel-pinecone</module>
         <module>camel-platform-http</module>
+        <module>camel-platform-http-jolokia</module>
         <module>camel-platform-http-main</module>
         <module>camel-platform-http-vertx</module>
         <module>camel-plc4x</module>
@@ -218,6 +229,7 @@
         <module>camel-pubnub</module>
         <module>camel-pulsar</module>
         <module>camel-python</module>
+        <module>camel-qdrant</module>
         <module>camel-quartz</module>
         <module>camel-quickfix</module>
         <module>camel-reactive-executor-tomcat</module>
@@ -295,6 +307,7 @@
         <module>camel-vertx</module>
         <module>camel-vm</module>
         <module>camel-wal</module>
+        <module>camel-wasm</module>
         <module>camel-weather</module>
         <module>camel-web3j</module>
         <module>camel-webhook</module>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -357,6 +357,63 @@
         <bundle dependency='true'>mvn:org.apache.avro/avro/${avro-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-avro/${project.version}</bundle>
     </feature>
+    <feature name='camel-avro-rpc' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.avro/avro/${avro-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-server/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-servlet/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-http/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-io/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-security/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-util/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-util-ajax/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/${javax-servlet3-api-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.avro/avro-ipc/${avro-ipc-netty-version}</bundle>
+        <!-- Use the wrap protocol to import the same version of javax.servlet-api as the rest-->
+        <bundle dependency='true'>wrap:mvn:org.apache.avro/avro-ipc-jetty/${avro-ipc-jetty-version}$overwrite=merge&amp;Import-Package=javax.servlet*;version:="[3.1,4)",*</bundle>
+        <bundle dependency='true'>mvn:org.apache.avro/avro-ipc-netty/${avro-ipc-netty-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-avro-rpc/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-avro-rpc-jetty/${project.version}</bundle>
+    </feature>
+    <feature name='camel-aws-bedrock' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
+        <feature version="${aws-java-sdk2-version}">awssdk</feature>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/bedrock/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/bedrockruntime/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/bedrockagent/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/bedrockagentruntime/${aws-java-sdk2-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-bedrock/${project.version}</bundle>
+    </feature>
+    <feature name='camel-aws-cloudtrail' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
+        <feature version="${aws-java-sdk2-version}">awssdk</feature>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-cloudtrail/${project.version}</bundle>
+    </feature>
+    <feature name='camel-aws-config' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="${aws-java-sdk2-version}">awssdk</feature>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/config/${aws-java-sdk2-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-config/${project.version}</bundle>
+    </feature>
+    <feature name='camel-aws-secrets-manager' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="${aws-java-sdk2-version}">awssdk</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/secretsmanager/${aws-java-sdk2-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-secrets-manager/${project.version}</bundle>
+    </feature>
+    <feature name='camel-aws-xray' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-core/${aws-xray-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-xray/${project.version}</bundle>
+    </feature>
     <feature name='camel-aws2-athena' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
@@ -498,31 +555,6 @@
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/translate/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-translate/${project.version}</bundle>
     </feature>
-    <feature name='camel-aws-cloudtrail' version='${project.version}' start-level='50'>
-        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
-        <feature version="${aws-java-sdk2-version}">awssdk</feature>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-aws-cloudtrail/${project.version}</bundle>
-    </feature>
-    <feature name='camel-aws-config' version='${project.version}' start-level='50'>
-        <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <feature version="${aws-java-sdk2-version}">awssdk</feature>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/config/${aws-java-sdk2-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-aws-config/${project.version}</bundle>
-    </feature>
-    <feature name='camel-aws-secrets-manager' version='${project.version}' start-level='50'>
-        <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <feature version="${aws-java-sdk2-version}">awssdk</feature>
-        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/secretsmanager/${aws-java-sdk2-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-aws-secrets-manager/${project.version}</bundle>
-    </feature>
-    <feature name='camel-aws-xray' version='${project.version}' start-level='50'>
-        <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-core/${aws-xray-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-aws-xray/${project.version}</bundle>
-    </feature>
     <feature name='camel-azure-cosmosdb' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
@@ -615,6 +647,11 @@
         <bundle dependency='true'>wrap:mvn:com.google.zxing/core/${zxing-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.zxing/javase/${zxing-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-barcode/${project.version}</bundle>
+    </feature>
+    <feature name='camel-beanio' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>mvn:com.github.beanio/beanio/${beanio-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-beanio/${project.version}</bundle>
     </feature>
     <feature name='camel-bindy' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -795,9 +832,53 @@
         <bundle dependency='true'>wrap:mvn:com.lihaoyi/ujson_2.13/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-datasonnet/${project.version}</bundle>
     </feature>
+    <feature name='camel-debezium-common' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-api/${kafka-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-json/${kafka-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-api/${debezium-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-embedded/${debezium-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-core/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-db2' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-db2/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-db2/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-mongodb' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-mongodb/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-mongodb/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-mysql' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-mysql/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-mysql/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-oracle' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-oracle/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-oracle/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-postgres' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-postgres/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-postgres/${project.version}</bundle>
+    </feature>
+    <feature name='camel-debezium-sqlserver' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-sqlserver/${debezium-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-sqlserver/${project.version}</bundle>
+    </feature>
     <feature name='camel-debug' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-debug/${project.version}</bundle>
+    </feature>
+    <feature name='camel-dhis2' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-jackson</feature>
+        <bundle dependency='true'>wrap:mvn:org.hisp.dhis.integration.sdk/dhis2-java-sdk/${auto-detect-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-dhis2/${project.version}</bundle>
     </feature>
     <feature name='camel-digitalocean' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -911,6 +992,19 @@
         <bundle dependency='true'>wrap:mvn:com.alibaba.fastjson2/fastjson2/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.alibaba.fastjson2/fastjson2-extension/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-fastjson/${project.version}</bundle>
+    </feature>
+    <feature name='camel-fhir' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <feature version="[4,5)">http-client</feature>
+        <feature version='[32,33)'>guava</feature>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-text/${commons-text-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
+        <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
+        <bundle dependency='true'>mvn:ca.uhn.hapi.fhir/hapi-fhir-base/${hapi-fhir-version}</bundle>
+        <bundle dependency='true'>mvn:ca.uhn.hapi.fhir/hapi-fhir-client/${hapi-fhir-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-fhir/${project.version}</bundle>
     </feature>
     <feature name='camel-file-watch' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1090,6 +1184,19 @@
         <bundle dependency='true'>wrap:mvn:io.grpc/grpc-util/${grpc-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub/${project.version}</bundle>
     </feature>
+    <feature name='camel-google-pubsub-lite' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="[33,34)">guava</feature>
+        <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.api/gax/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-pubsub-v1/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${google-auth-library-oauth2-http-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsublite/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub-lite/${project.version}</bundle>
+    </feature>
     <feature name='camel-google-secret-manager' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[33,34)">guava</feature>
@@ -1228,6 +1335,50 @@
         <bundle>mvn:org.apache.camel.karaf/camel-http/${project.version}</bundle>
         <bundle dependency="true">wrap:mvn:org.apache.httpcomponents.core5/httpcore5-h2/${httpcore-version}</bundle>
     </feature>
+    <feature name='camel-huaweicloud-common' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-core/${huaweicloud-sdk-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-common/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-dms' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-dms/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-frs' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-frs/${huaweicloud-sdk-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-frs/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-functiongraph' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-functiongraph/${huaweicloud-sdk-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-functiongraph/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-iam' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-iam/${huaweicloud-sdk-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-iam/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-imagerecognition' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-image/${huaweicloud-sdk-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-imagerecognition/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-obs' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${gson-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud/esdk-obs-java/${huaweicloud-obs-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-obs/${project.version}</bundle>
+    </feature>
+    <feature name='camel-huaweicloud-smn' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-huaweicloud-common</feature>
+        <bundle dependency='true'>wrap:mvn:com.huaweicloud.sdk/huaweicloud-sdk-smn/${huaweicloud-sdk-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-huaweicloud-smn/${project.version}</bundle>
+    </feature>
     <feature name='camel-ical' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
@@ -1264,6 +1415,25 @@
         <bundle dependency='true'>wrap:mvn:org.apache.ignite/ignite-core/${ignite-version}</bundle>
         <bundle dependency='true'>mvn:javax.cache/cache-api/${jcache-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ignite/${project.version}</bundle>
+    </feature>
+    <feature name='camel-infinispan' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-infinispan-common</feature>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-client-hotrod/${infinispan-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-remote-query-client/${infinispan-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-infinispan/${project.version}</bundle>
+    </feature>
+    <feature name='camel-infinispan-common' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-commons/${infinispan-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-query-dsl/${infinispan-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-infinispan-common/${project.version}</bundle>
+    </feature>
+    <feature name='camel-infinispan-embedded' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-infinispan-common</feature>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-core/${infinispan-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-query/${infinispan-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-component-annotations/${infinispan-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-infinispan-embedded/${project.version}</bundle>
     </feature>
     <feature name='camel-influxdb' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1550,6 +1720,19 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-kamelet/${project.version}</bundle>
     </feature>
+    <feature name='camel-knative' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-cloudevents</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson2-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-knative/${project.version}</bundle>
+    </feature>
+    <feature name='camel-knative-http' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-knative</feature>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web-client/${vertx-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-knative-http/${project.version}</bundle>
+    </feature>
     <feature name='camel-kubernetes' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
@@ -1595,6 +1778,16 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.kudu/kudu-client/${kudu-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-kudu/${project.version}</bundle>
+    </feature>
+    <feature name='camel-langchain4j-chat' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:dev.langchain4j/langchain4j-core/${langchain4j-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-langchain4j-chat/${project.version}</bundle>
+    </feature>
+    <feature name='camel-langchain4j-embeddings' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:dev.langchain4j/langchain4j-core/${langchain4j-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-langchain4j-embeddings/${project.version}</bundle>
     </feature>
     <feature name='camel-ldap' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1709,6 +1902,51 @@
         <bundle dependency='true'>mvn:io.prometheus/simpleclient_tracer_otel_agent/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:io.smallrye/jandex/${jandex-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-micrometer-prometheus/${project.version}</bundle>
+    </feature>
+    <feature name='camel-microprofile-config' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:io.smallrye.config/smallrye-config/${smallrye-config-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.smallrye.config/smallrye-config-core/${smallrye-config-version}</bundle>
+        <!-- Use wrap protocol to change the way to configure that the bundle needs some SPI -->
+        <bundle dependency='true'>wrap:mvn:org.eclipse.microprofile.config/microprofile-config-api/${microprofile-config-version}$overwrite=full&amp;${spi-consumer}&amp;Import-Package=*</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.cdi-api/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.inject/jakarta.inject-api/${jakarta-inject-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.el/jakarta.el-api/${jakarta-el-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.interceptor/jakarta.interceptor-api/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.lang-model/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-microprofile-config/${project.version}</bundle>
+    </feature>
+    <feature name='camel-microprofile-fault-tolerance' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:io.smallrye/smallrye-fault-tolerance/${smallrye-fault-tolerance-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.smallrye/smallrye-fault-tolerance-core/${smallrye-fault-tolerance-version}</bundle>
+        <!-- Use the wrap protocol to change the version of cdi-api for something that matches with the runtime -->
+        <bundle dependency='true'>wrap:mvn:org.eclipse.microprofile.fault-tolerance/microprofile-fault-tolerance-api/${microprofile-fault-tolerance-version}$overwrite=merge&amp;Import-Package=jakarta.enterprise.util*;version='[4,5)',*</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.cdi-api/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.el/jakarta.el-api/${jakarta-el-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.interceptor/jakarta.interceptor-api/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.lang-model/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.inject/jakarta.inject-api/${jakarta-inject-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-microprofile-fault-tolerance/${project.version}</bundle>
+    </feature>
+    <feature name='camel-microprofile-health' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:io.smallrye/smallrye-health/${smallrye-health-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.smallrye/smallrye-health-api/${smallrye-health-version}</bundle>
+        <!-- Use the wrap protocol to change the version of cdi-api for something that matches with the runtime -->
+        <bundle dependency='true'>wrap:mvn:org.eclipse.microprofile.health/microprofile-health-api/${auto-detect-version}$overwrite=merge&amp;Import-Package=jakarta.enterprise.util*;version='[4,5)',*</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.cdi-api/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.el/jakarta.el-api/${jakarta-el-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.interceptor/jakarta.interceptor-api/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.enterprise/jakarta.enterprise.lang-model/${jakarta-enterprise-cdi-api-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.inject/jakarta.inject-api/${jakarta-inject-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-microprofile-health/${project.version}</bundle>
+    </feature>
+    <feature name='camel-milvus' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:dev.langchain4j/langchain4j-core/${langchain4j-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.milvus/milvus-sdk-java/${milvus-client-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-milvus/${project.version}</bundle>
     </feature>
     <feature name='camel-mina' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1942,10 +2180,32 @@
         <bundle dependency='true'>wrap:mvn:com.impossibl.pgjdbc-ng/pgjdbc-ng/${pgjdbc-ng-driver-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pgevent/${project.version}</bundle>
     </feature>
+    <feature name='camel-pinecone' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:dev.langchain4j/langchain4j-core/${langchain4j-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.pinecone/pinecone-client/${pinecone-client-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-pinecone/${project.version}</bundle>
+    </feature>
     <feature name='camel-platform-http' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-http-base/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-platform-http/${project.version}</bundle>
+    </feature>
+    <feature name='camel-platform-http-jolokia' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-platform-http</feature>
+        <feature version='[4.1,5)'>netty</feature>
+        <feature version="[5,6)">jakarta-servlet</feature>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-core/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.vertx/vertx-web/${vertx-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.jolokia/jolokia-agent-jvm/${jolokia-version}</bundle>
+        <!-- Use the wrap protocol to work-around problems with exported and imported packages -->
+        <bundle dependency='true'>wrap:mvn:org.jolokia/jolokia-server-core/${jolokia-version}$overwrite=merge&amp;Import-Package=org.osgi*;resolution:=optional,!org.jolokia.server.core*,*&amp;Export-Package=org.jolokia.*;version=${jolokia-version}</bundle>
+        <!-- Use the wrap protocol because it doesn't export org.jolokia.service.jmx -->
+        <bundle dependency='true'>wrap:mvn:org.jolokia/jolokia-service-jmx/${jolokia-version}$overwrite=merge&amp;Export-Package=org.jolokia.*;version=${jolokia-version}</bundle>
+        <!-- Use the wrap protocol because it doesn't export org.jolokia.service.serializer -->
+        <bundle dependency='true'>wrap:mvn:org.jolokia/jolokia-service-serializer/${jolokia-version}$overwrite=merge&amp;Export-Package=org.jolokia.*;version=${jolokia-version}</bundle>
+        <bundle dependency='true'>mvn:com.googlecode.json-simple/json-simple/${auto-detect-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-platform-http-jolokia/${project.version}</bundle>
     </feature>
     <feature name='camel-platform-http-main' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-platform-http-vertx</feature>
@@ -2002,6 +2262,18 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.python/jython-standalone/${jython-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-python/${project.version}</bundle>
+    </feature>
+    <feature name='camel-qdrant' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version="[33,34)">guava</feature>
+        <bundle dependency='true'>wrap:mvn:dev.langchain4j/langchain4j-core/${langchain4j-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.qdrant/client/${qdrant-client-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-api/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-protobuf/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-services/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-stub/${grpc-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.grpc/grpc-netty-shaded/${grpc-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-qdrant/${project.version}</bundle>
     </feature>
     <feature name='camel-quartz' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -2521,6 +2793,13 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-wal/${project.version}</bundle>
     </feature>
+    <feature name='camel-wasm' version='${project.version}' start-level='50'>
+        <feature version='${camel-osgi-version-range}'>camel-core</feature>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:com.dylibso.chicory/runtime/${chicocy-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.dylibso.chicory/wasm/${chicocy-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-wasm/${project.version}</bundle>
+    </feature>
     <feature name='camel-weather' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
@@ -2608,8 +2887,8 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-client-java/${zeebe.version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-gateway-protocol-impl/${zeebe.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-client-java/${zeebe-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.camunda/zeebe-gateway-protocol-impl/${zeebe-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.grpc/grpc-api/${grpc-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zeebe/${project.version}</bundle>
     </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
         <bouncycastle-version>1.78</bouncycastle-version>
         <box-java-sdk-version>4.8.0</box-java-sdk-version>
         <braintree-gateway-version>3.34.0</braintree-gateway-version>
-        <build-helper-maven-plugin-version>3.5.0</build-helper-maven-plugin-version>
         <bytebuddy-version>1.14.14</bytebuddy-version>
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.8</caffeine-version>
@@ -127,7 +126,7 @@
         <camunda-version>7.21.0</camunda-version>
         <camel-k-version>2.3.0</camel-k-version>
         <cassandra-driver-version>4.17.0</cassandra-driver-version>
-        <jta-api-1.2-version>1.2</jta-api-1.2-version>
+        <jta-api-1-2-version>1.2</jta-api-1-2-version>
         <cglib-version>3.3.0</cglib-version>
         <chicocy-version>0.0.9</chicocy-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
@@ -155,12 +154,10 @@
         <commons-validator-version>1.8.0</commons-validator-version>
         <compress-lzf-version>1.1.2</compress-lzf-version>
         <consul-client-version>1.3.2</consul-client-version>
-        <cobertura-maven-plugin-version>2.7</cobertura-maven-plugin-version>
         <couchbase-client-version>3.6.2</couchbase-client-version>
         <curator-version>5.6.0</curator-version>
         <cxf-version>4.0.4</cxf-version>
         <cxf-codegen-plugin-version>4.0.4</cxf-codegen-plugin-version>
-        <!-- cxf-xjc is not released as often -->
         <cxf-xjc-plugin-version>4.0.1</cxf-xjc-plugin-version>
         <cxf-xjc-utils-version>4.0.1</cxf-xjc-utils-version>
         <datasonnet-mapper-version>2.5.2-jakarta4</datasonnet-mapper-version>
@@ -183,27 +180,24 @@
         <elasticsearch-java-client-version>8.13.3</elasticsearch-java-client-version>
         <elasticsearch-java-client-sniffer-version>8.13.3</elasticsearch-java-client-sniffer-version>
         <elytron-web>4.1.0.Final</elytron-web>
-        <exec-maven-plugin-version>3.2.0</exec-maven-plugin-version>
         <fastjson-version>2.0.49</fastjson-version>
-        <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
         <google-maps-services-version>2.2.0</google-maps-services-version>
         <flatpack-version>4.0.18</flatpack-version>
         <flink-version>1.19.0</flink-version>
         <fop-version>2.9</fop-version>
-        <formatter-maven-plugin-version>2.23.0</formatter-maven-plugin-version>
         <ftpserver-version>1.2.0</ftpserver-version>
         <freemarker-version>2.3.32</freemarker-version>
-        <geronimo-annotation-1.0-spec-version>1.1.1</geronimo-annotation-1.0-spec-version>
-        <geronimo-annotation-1.2-spec-version>1.0</geronimo-annotation-1.2-spec-version>
-        <geronimo-atinject-1.0-spec-version>1.0</geronimo-atinject-1.0-spec-version>
+        <geronimo-annotation-1-0-spec-version>1.1.1</geronimo-annotation-1-0-spec-version>
+        <geronimo-annotation-1-2-spec-version>1.0</geronimo-annotation-1-2-spec-version>
+        <geronimo-atinject-1-0-spec-version>1.0</geronimo-atinject-1-0-spec-version>
         <geronimo-el-spec-version>1.0.1</geronimo-el-spec-version>
-        <geronimo-interceptor-1.1-spec-version>1.0</geronimo-interceptor-1.1-spec-version>
-        <geronimo-interceptor-1.2-spec-version>1.0</geronimo-interceptor-1.2-spec-version>
+        <geronimo-interceptor-1-1-spec-version>1.0</geronimo-interceptor-1-1-spec-version>
+        <geronimo-interceptor-1-2-spec-version>1.0</geronimo-interceptor-1-2-spec-version>
         <geronimo-j2ee-connector-spec-version>2.0.0</geronimo-j2ee-connector-spec-version>
         <geronimo-j2ee-jacc-spec-version>1.1</geronimo-j2ee-jacc-spec-version>
         <geronimo-j2ee-management-spec-version>1.1</geronimo-j2ee-management-spec-version>
-        <geronimo-jcdi-1.0-spec-version>1.0</geronimo-jcdi-1.0-spec-version>
-        <geronimo-jcdi-1.1-spec-version>1.0</geronimo-jcdi-1.1-spec-version>
+        <geronimo-jcdi-1-0-spec-version>1.0</geronimo-jcdi-1-0-spec-version>
+        <geronimo-jcdi-1-1-spec-version>1.0</geronimo-jcdi-1-1-spec-version>
         <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
         <jakarta-persistence-api-version>3.1.0</jakarta-persistence-api-version>
         <jakarta-json-api-version>2.1.3</jakarta-json-api-version>
@@ -215,7 +209,6 @@
         <jaxb-osgi-version>4.0.5</jaxb-osgi-version>
         <jaxb-xjc-version>4.0.5</jaxb-xjc-version>
         <jaxb-jxc-version>4.0.5</jaxb-jxc-version>
-        <gmavenplus-plugin-version>3.0.2</gmavenplus-plugin-version>
         <google-auth-library-oauth2-http-version>1.23.0</google-auth-library-oauth2-http-version>
         <google-api-client-version>2.4.1</google-api-client-version>
         <google-api-services-drive-version>v3-rev20240327-2.0.0</google-api-services-drive-version>
@@ -233,7 +226,6 @@
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
         <groovy-version>4.0.21</groovy-version>
         <grpc-version>1.63.0</grpc-version>
-        <!-- keep grpc-google-auth-library-version in sync with that used by grpc-auth -->
         <grpc-google-auth-library-version>1.23.0</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.4.0</grpc-java-jwt-version>
         <grpc-netty-tcnative-boringssl-static-version>2.0.59.Final</grpc-netty-tcnative-boringssl-static-version>
@@ -262,7 +254,6 @@
         <ical4j-version>3.2.18</ical4j-version>
         <icu4j-version>75.1</icu4j-version>
         <ignite-version>2.16.0</ignite-version>
-        <impsort-maven-plugin-version>1.9.0</impsort-maven-plugin-version>
         <infinispan-version>15.0.2.Final</infinispan-version>
         <influx-java-driver-version>2.24</influx-java-driver-version>
         <influx-client-java-driver-version>7.0.0</influx-client-java-driver-version>
@@ -279,7 +270,6 @@
         <java-grok-version>0.1.9</java-grok-version>
         <java-util-version>2.9.0</java-util-version>
         <jnats-version>2.17.6</jnats-version>
-        <javacc-maven-plugin-version>3.1.0</javacc-maven-plugin-version>
         <javacrumbs-version>0.22</javacrumbs-version>
         <javaparser-version>3.13.10</javaparser-version>
         <javapoet-version>1.13.0</javapoet-version>
@@ -296,12 +286,11 @@
         <jakarta-xml-ws-api-version>4.0.1</jakarta-xml-ws-api-version>
         <glassfish-javax-json>1.1.4</glassfish-javax-json>
         <glassfish-jaxb-runtime-version>4.0.5</glassfish-jaxb-runtime-version>
-        <jaxb2-maven-plugin-version>3.2.0</jaxb2-maven-plugin-version>
         <jaxp-ri-version>1.4.5</jaxp-ri-version>
-        <jboss-el-api_3.0_spec-version>2.0.0.Final</jboss-el-api_3.0_spec-version>
+        <jboss-el-api_3-0_spec-version>2.0.0.Final</jboss-el-api_3-0_spec-version>
         <jboss-logging-version>3.5.3.Final</jboss-logging-version>
         <jboss-marshalling-version>1.4.10.Final</jboss-marshalling-version>
-        <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
+        <jboss-transaction-spi-version>7.6.1.Final</jboss-transaction-spi-version>
         <jboss-xnio-version>3.3.8.Final</jboss-xnio-version>
         <jcache-version>1.1.1</jcache-version>
         <jcr-version>2.0</jcr-version>
@@ -356,7 +345,6 @@
         <leveldb-api-version>0.12</leveldb-api-version>
         <leveldb-version>0.12</leveldb-version>
         <libphonenumber-version>8.13.33</libphonenumber-version>
-        <!-- virtual dependency only used by Eclipse m2e -->
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
         <log4j2-version>2.21.1</log4j2-version>
         <logback-version>1.5.6</logback-version>
@@ -414,10 +402,8 @@
         <pinecone-client-version>1.0.0</pinecone-client-version>
         <plc4x-version>0.12.0</plc4x-version>
         <pooled-jms-version>3.1.6</pooled-jms-version>
-        <properties-maven-plugin-version>1.2.1</properties-maven-plugin-version>
         <proto-google-common-protos-version>2.22.0</proto-google-common-protos-version>
         <protobuf-version>3.25.3</protobuf-version>
-        <protobuf-maven-plugin-version>0.6.1</protobuf-maven-plugin-version>
         <protonpack-version>1.8</protonpack-version>
         <protostream-version>5.0.3.Final</protostream-version>
         <prowide-version>SRU2023-10.1.5</prowide-version>
@@ -465,7 +451,6 @@
         <spring-rabbitmq-version>3.1.4</spring-rabbitmq-version>
         <spring-security-version>6.2.4</spring-security-version>
         <spring-ws-version>4.0.10</spring-ws-version>
-        <sql-maven-plugin-version>3.0.0</sql-maven-plugin-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>
         <sshd-version>2.12.1</sshd-version>
@@ -476,7 +461,7 @@
         <swagger-openapi3-java-parser-version>2.1.22</swagger-openapi3-java-parser-version>
         <stax-api-version>1.0.1</stax-api-version>
         <stringtemplate-version>4.3.4</stringtemplate-version>
-        <testcontainers-version>1.19.8</testcontainers-version>
+        <testcontainers-version>1.19.7</testcontainers-version>
         <thymeleaf-version>3.1.2.RELEASE</thymeleaf-version>
         <tika-version>2.9.2</tika-version>
         <twilio-version>10.1.5</twilio-version>
@@ -499,7 +484,6 @@
         <xbean-asm5-shaded-version>4.5</xbean-asm5-shaded-version>
         <xchange-version>5.1.1</xchange-version>
         <xerces-version>2.12.2</xerces-version>
-        <!-- needed to manage the xml-apis version in camel-xmljson -->
         <xml-apis-version>1.4.01</xml-apis-version>
         <xml-apis-ext-version>1.3.04</xml-apis-ext-version>
         <xml-resolver-version>1.2</xml-resolver-version>
@@ -508,7 +492,7 @@
         <xpp3-version>1.1.4c</xpp3-version>
         <yasson-version>3.0.3</yasson-version>
         <yetus-audience-annotations-version>0.15.0</yetus-audience-annotations-version>
-        <zeebe.version>8.5.0</zeebe.version>
+        <zeebe-version>8.5.0</zeebe-version>
         <zendesk-client-version>0.25.0</zendesk-client-version>
         <zookeeper-version>3.9.2</zookeeper-version>
         <zxing-version>3.5.3</zxing-version>
@@ -560,6 +544,7 @@
         <jakarta-validation-api-version>3.0.2</jakarta-validation-api-version>
         <jakarta-ws-rs-api-version>3.1.0</jakarta-ws-rs-api-version>
         <jakarta-xml-bind3-api-version>3.0.1</jakarta-xml-bind3-api-version>
+        <javax-servlet3-api-version>3.1.0</javax-servlet3-api-version>
         <jaxb3-core-version>3.0.2</jaxb3-core-version>
         <jaxb3-impl-version>3.0.2</jaxb3-impl-version>
         <jaxb3-osgi-version>3.0.2</jaxb3-osgi-version>


### PR DESCRIPTION
fixes #375 

## Motivation

After the migration to Camel 4.6, it appears that some components were missing, so we need to add them

## Modifications:

* Move the AI components into the `camel-ai` module
* Add the wrapper of the missing components
* Add the feature of the missing components