### PR TITLE
Add camel-aws2-iam-test

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -510,6 +510,7 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/mq/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-mq/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-msk' version='${project.version}' start-level='50'>

--- a/tests/features/camel-aws2-iam/pom.xml
+++ b/tests/features/camel-aws2-iam/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-aws2-iam-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: AWS2 IAM</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws2-iam</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-aws2-iam/src/main/java/org/apache/karaf/camel/test/CamelAws2IamRouteSupplier.java
+++ b/tests/features/camel-aws2-iam/src/main/java/org/apache/karaf/camel/test/CamelAws2IamRouteSupplier.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.builder.Builder.constant;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.iam.IAM2Component;
+import org.apache.camel.component.aws2.iam.IAM2Configuration;
+import org.apache.camel.component.aws2.iam.IAM2Constants;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+@Component(name = "karaf-camel-aws2-iam-test", immediate = true, service = CamelRouteSupplier.class)
+public class CamelAws2IamRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String REGION = System.getProperty("localstack.iam.region");
+    private static final String ACCESS_KEY = System.getProperty("localstack.iam.accessKey");
+    private static final String SECRET_KEY = System.getProperty("localstack.iam.secretKey");
+    private static final String COMPONENT_NAME = "aws2-iam";
+
+    @Override
+    public void configure(CamelContext camelContext) {
+        final IAM2Component aws2IamComponent = new IAM2Component();
+        final IAM2Configuration configuration = new IAM2Configuration();
+        configuration.setAccessKey(ACCESS_KEY);
+        configuration.setSecretKey(SECRET_KEY);
+        configuration.setRegion(REGION);
+        aws2IamComponent.setConfiguration(configuration);
+        camelContext.addComponent(COMPONENT_NAME, aws2IamComponent);
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        configureConsumer(producerRoute
+                .setHeader(IAM2Constants.USERNAME, constant("testUser1"))
+                .to("aws2-iam://test?operation=createUser")
+                .setHeader(IAM2Constants.USERNAME, constant("testUser2"))
+                .to("aws2-iam://test?operation=createUser")
+                .log("User Created: ${body}")
+                .to("aws2-iam://test?operation=deleteUser")
+                .to("aws2-iam://test?operation=listUsers")
+                .log("List users: ${body}")
+                );
+    }
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+}

--- a/tests/features/camel-aws2-iam/src/test/java/org/apache/karaf/camel/itest/CamelAws2IamITest.java
+++ b/tests/features/camel-aws2-iam/src/test/java/org/apache/karaf/camel/itest/CamelAws2IamITest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Predicate;
+import org.apache.camel.component.mock.MockEndpoint;
+
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+@CamelKarafTestHint(externalResourceProvider = CamelAws2IamITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelAws2IamITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedMessagesMatches(new Predicate() {
+            @Override
+            public boolean matches(Exchange exchange) {
+                String body = exchange.getIn().getBody(String.class);
+                return body.contains("UserName=testUser1") && !body.contains("UserName=testUser2");
+            }
+        });
+
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final String ACCESS_KEY = "test";
+        private static final String SECRET_KEY = "test";
+        private static final String REGION = "us-east-1";
+
+        public static GenericContainerResource<LocalStackContainer> createAws2IamContainer() {
+
+            final LocalStackContainer localStackContainer =
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4.0")).withServices(
+                            LocalStackContainer.Service.IAM).waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+
+            return new GenericContainerResource<>(localStackContainer, resource -> {
+                try {
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_access_key_id", ACCESS_KEY, "--profile",
+                            "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_secret_access_key", SECRET_KEY,
+                            "--profile", "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "region", REGION, "--profile", "localstack");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                resource.setProperty("localstack.iam.accessKey", ACCESS_KEY);
+                resource.setProperty("localstack.iam.secretKey", SECRET_KEY);
+                resource.setProperty("localstack.iam.region", REGION);
+            });
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -40,6 +40,7 @@
         <module>camel-activemq</module>
         <module>camel-amqp</module>
         <module>camel-arangodb</module>
+        <module>camel-aws2-iam</module>
         <module>camel-aws2-s3</module>
         <module>camel-aws2-ses</module>
         <module>camel-aws2-sns</module>


### PR DESCRIPTION
Fixes #402 
Add camel-aws2-iam-test
also fixed the camel-aws2-mq  (cannot be tested in integration test because local stack community doesn't provide it) but when trying to do it, the missing json dependency was raised