### PR TITLE
Add camel-base64 integration test

### DIFF
--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/AbstractCamelRouteWithBundleITest.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/AbstractCamelRouteWithBundleITest.java
@@ -17,12 +17,14 @@
 
 package org.apache.karaf.camel.itests;
 
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
-
-import static org.ops4j.pax.exam.OptionUtils.combine;
 
 public abstract class AbstractCamelRouteWithBundleITest extends AbstractCamelRouteITest {
 
@@ -41,7 +43,8 @@ public abstract class AbstractCamelRouteWithBundleITest extends AbstractCamelRou
             throw new IllegalArgumentException("The system property project.version must be set to the version of the " +
                     "test bundle to install or the method getTestBundleVersion must be overridden to provide the version");
         }
-        installBundle("file://%s/%s-%s.jar".formatted(getBaseDir(), testBundleName, testBundleVersion), true);
+        Path bundlePath = Paths.get("%s/%s-%s.jar".formatted(getBaseDir(), testBundleName, testBundleVersion));
+        installBundle(bundlePath.toUri().toString(), true);
         assertBundleInstalledAndRunning(testBundleName);
         return List.of(testBundleName);
     }

--- a/tests/features/camel-base64/pom.xml
+++ b/tests/features/camel-base64/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-base64-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Base64</name>
+
+</project>

--- a/tests/features/camel-base64/src/main/java/org/apache/karaf/camel/test/CamelBase64RouteSupplier.java
+++ b/tests/features/camel-base64/src/main/java/org/apache/karaf/camel/test/CamelBase64RouteSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+@Component(name = "karaf-camel-base64-test", immediate = true, service = CamelRouteSupplier.class)
+public class CamelBase64RouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String ORIGINAL_STRING = "Hello Base64! 1234567890 ~`!@#$%^&*()-_=+[]{}|;:'\",.<>?/";
+    private static final int ENCODER_LINE_LENGTH = 9;
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute.process(ex -> ex.getIn().setBody(ORIGINAL_STRING))
+            .log("Will encode: ${body}")
+            .marshal().base64(ENCODER_LINE_LENGTH, System.lineSeparator(), true)
+            .log("Will decode: ${body}")
+            .unmarshal().base64()
+            .log("Decoded: ${body}")
+            .toF("mock:%s", getResultMockName());
+    }
+
+}

--- a/tests/features/camel-base64/src/test/java/org/apache/karaf/camel/itest/CamelBase64ITest.java
+++ b/tests/features/camel-base64/src/test/java/org/apache/karaf/camel/itest/CamelBase64ITest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelBase64ITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    private static final String ORIGINAL_STRING = "Hello Base64! 1234567890 ~`!@#$%^&*()-_=+[]{}|;:'\",.<>?/";
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived(ORIGINAL_STRING);
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -51,6 +51,7 @@
         <module>camel-aws2-sts</module>
         <module>camel-azure-storage-blob</module>
         <module>camel-barcode</module>
+        <module>camel-base64</module>
         <module>camel-core</module>
         <module>camel-ehcache</module>
         <module>camel-elasticsearch</module>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/416

- Add camel-base64 integration test.
- Fix integration tests path for Windows.