### PR TITLE
Add camel-bean-validator integration test

### DIFF
--- a/components/camel-bean-validator/pom.xml
+++ b/components/camel-bean-validator/pom.xml
@@ -36,8 +36,11 @@
         <camel.osgi.export>
             org.apache.camel.component.bean.validator*;version=${camel-version}
         </camel.osgi.export>
+        <camel-osgi-camel-import>
+            !org.apache.camel.component.bean.validator,
+            org.apache.camel.*;${camel-osgi-import-camel-version},</camel-osgi-camel-import>
         <camel.osgi.import>
-            !org.apache.camel.component.bean.validator,*
+            *
         </camel.osgi.import>
         <camel.osgi.activator>org.apache.camel.component.bean.validator.osgi.Activator</camel.osgi.activator>
     </properties>

--- a/components/camel-bean-validator/pom.xml
+++ b/components/camel-bean-validator/pom.xml
@@ -34,11 +34,12 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel-version}
+            org.apache.camel.component.bean.validator*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
-            *
+            !org.apache.camel.component.bean.validator,*
         </camel.osgi.import>
+        <camel.osgi.activator>org.apache.camel.component.bean.validator.osgi.Activator</camel.osgi.activator>
     </properties>
 
     <dependencies>
@@ -53,10 +54,42 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta-validation-api-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+            <version>${camel-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- osgi support -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>recompile</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/osgi/Activator.java
+++ b/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/osgi/Activator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean.validator.osgi;
+
+import org.apache.camel.component.bean.validator.ValidationProviderResolverFactory;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+public class Activator implements BundleActivator {
+    private ServiceRegistration<?> registration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        Object factory = new OsgiValidationProviderResolverFactory();
+        registration = context.registerService(ValidationProviderResolverFactory.class.getName(), factory, null);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        // release the reference
+        if (registration != null) {
+            context.ungetService(registration.getReference());
+        }
+    }
+
+}

--- a/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/osgi/OsgiValidationProviderResolverFactory.java
+++ b/components/camel-bean-validator/src/main/java/org/apache/camel/component/bean/validator/osgi/OsgiValidationProviderResolverFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.bean.validator.osgi;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.bean.validator.HibernateValidationProviderResolver;
+import org.apache.camel.component.bean.validator.ValidationProviderResolverFactory;
+
+import jakarta.validation.ValidationProviderResolver;
+
+public class OsgiValidationProviderResolverFactory implements ValidationProviderResolverFactory {
+
+    @Override
+    public ValidationProviderResolver createValidationProviderResolver(CamelContext camelContext) {
+        // in OSGi we use hibernate validator
+        return new HibernateValidationProviderResolver();
+    }
+}

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -671,12 +671,15 @@
         <bundle>mvn:org.apache.camel.karaf/camel-base64/${project.version}</bundle>
     </feature>
     <feature name='camel-bean-validator' version='${project.version}' start-level='50'>
+        <feature prerequisite="true">spifly</feature>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="[3,4)">jakarta-validation</feature>
-        <bundle>mvn:org.hibernate.validator/hibernate-validator/${hibernate-validator-version}</bundle>
-        <bundle>mvn:org.jboss.logging/jboss-logging/${jboss-logging-version}</bundle>
-        <bundle>mvn:com.fasterxml/classmate/${auto-detect-version}</bundle>
-        <bundle>mvn:jakarta.el/jakarta.el-api/${jakarta-el-api-version}</bundle>
+        <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
+        <bundle dependency='true'>wrap:mvn:org.hibernate.validator/hibernate-validator/${hibernate-validator-version}$overwrite=merge</bundle>
+        <bundle dependency='true'>mvn:org.jboss.logging/jboss-logging/${jboss-logging-version}</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml/classmate/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.glassfish.expressly/expressly/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:jakarta.el/jakarta.el-api/${jakarta-el5-api-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-bean-validator/${project.version}</bundle>
     </feature>
     <feature name='camel-barcode' version='${project.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,7 @@
         <httpcore4-version>4.4.16</httpcore4-version>
         <jackson216-version>2.16.2</jackson216-version>
         <jakarta-annotation2-api-version>2.1.1</jakarta-annotation2-api-version>
+        <jakarta-el5-api-version>5.0.0</jakarta-el5-api-version>
         <jakarta-servlet5-api-version>5.0.0</jakarta-servlet5-api-version>
         <jakarta-validation-api-version>3.0.2</jakarta-validation-api-version>
         <jakarta-ws-rs-api-version>3.1.0</jakarta-ws-rs-api-version>

--- a/tests/features/camel-bean-validator/pom.xml
+++ b/tests/features/camel-bean-validator/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-bean-validator-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: BeanValidator</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-bean-validator</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-bean-validator/pom.xml
+++ b/tests/features/camel-bean-validator/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>camel-bean-validator-test</artifactId>
-    <name>Apache Camel :: Karaf :: Tests :: Features :: BeanValidator</name>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Bean validator</name>
 
     <dependencies>
         <dependency>

--- a/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
+++ b/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
@@ -41,7 +41,7 @@ public class CamelBeanValidatorRouteSupplier extends AbstractCamelSingleFeatureR
 
     @Override
     protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
-        producerRoute.setBody(constant(new User("John",90)))
+        producerRoute.setBody(constant(new User("John", 90)))
                 .to("bean-validator://x")
                 .log("body {body}")
                 .toF("mock:%s", getResultMockName());

--- a/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
+++ b/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.builder.Builder.constant;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Component(
+        name = "karaf-camel-bean-validator-test",
+        immediate = true,
+        service = CamelBeanValidatorRouteSupplier.class
+)
+public class CamelBeanValidatorRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    public record User(@NotNull String name, @Min(18) int age) {}
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute.setBody(constant(new User("John",90)))
+                .to("bean-validator://x")
+                .log("body {body}")
+                .toF("mock:%s", getResultMockName());
+    }
+}
+

--- a/tests/features/camel-bean-validator/src/test/java/org/apache/karaf/camel/itest/CamelBeanValidatorITest.java
+++ b/tests/features/camel-bean-validator/src/test/java/org/apache/karaf/camel/itest/CamelBeanValidatorITest.java
@@ -34,12 +34,4 @@ public class CamelBeanValidatorITest extends AbstractCamelSingleFeatureResultMoc
     public void testResultMock() throws Exception {
         assertMockEndpointsSatisfied();
     }
-
-    /*@Override
-    protected List<String> installRequiredBundles() throws Exception {
-        List<String> result = super.installRequiredBundles();
-        result.add("mvn:org.hibernate.validator/hibernate-validator/8.0.1.Final");
-        return result;
-    }*/
-
 }

--- a/tests/features/camel-bean-validator/src/test/java/org/apache/karaf/camel/itest/CamelBeanValidatorITest.java
+++ b/tests/features/camel-bean-validator/src/test/java/org/apache/karaf/camel/itest/CamelBeanValidatorITest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelBeanValidatorITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("User[name=John, age=90]");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    /*@Override
+    protected List<String> installRequiredBundles() throws Exception {
+        List<String> result = super.installRequiredBundles();
+        result.add("mvn:org.hibernate.validator/hibernate-validator/8.0.1.Final");
+        return result;
+    }*/
+
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -54,6 +54,7 @@
         <!--module>camel-azure-storage-blob</module-->
         <module>camel-barcode</module>
         <module>camel-base64</module>
+        <module>camel-bean-validator</module>
         <module>camel-bindy</module>
         <module>camel-caffeine</module>
         <module>camel-cbor</module>


### PR DESCRIPTION
Fixes #434 camel-bean-validator integration test
Fix the component to add the code that was previously in camel-bean-validator-osgi which registers a default validator factory (as the hibernate one).
