### PR TITLE
Add camel-leveldb integration test

### DIFF
--- a/components/camel-leveldb/pom.xml
+++ b/components/camel-leveldb/pom.xml
@@ -37,7 +37,9 @@
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
-            *
+            *,
+            org.iq80.leveldb.impl;resolution:=optional,
+            org.fusesource.leveldbjni;resolution:=optional
         </camel.osgi.import>
     </properties>
 

--- a/components/camel-leveldb/pom.xml
+++ b/components/camel-leveldb/pom.xml
@@ -37,9 +37,9 @@
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
-            *,
             org.iq80.leveldb.impl;resolution:=optional,
-            org.fusesource.leveldbjni;resolution:=optional
+            org.fusesource.leveldbjni;resolution:=optional,
+            *
         </camel.osgi.import>
     </properties>
 

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1884,6 +1884,7 @@
     <feature name='camel-leveldb' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:org.iq80.leveldb/leveldb/${leveldb-version}</bundle>
         <bundle dependency='true'>mvn:org.fusesource.leveldbjni/leveldbjni-all/${leveldbjni-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-leveldb/${project.version}</bundle>
     </feature>

--- a/tests/features/camel-leveldb/pom.xml
+++ b/tests/features/camel-leveldb/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-leveldb-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: LevelDB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-leveldb</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-leveldb/src/main/java/org/apache/karaf/camel/test/CamelLeveldbRouteSupplier.java
+++ b/tests/features/camel-leveldb/src/main/java/org/apache/karaf/camel/test/CamelLeveldbRouteSupplier.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.builder.Builder.constant;
+import static org.apache.camel.builder.Builder.header;
+
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.leveldb.LevelDBAggregationRepository;
+import org.apache.camel.component.leveldb.serializer.JacksonLevelDBSerializer;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+        name = "karaf-camel-leveldb-test",
+        immediate = true,
+        service = CamelLeveldbRouteSupplier.class
+)
+public class CamelLeveldbRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    static class StringAggregationStrategy implements AggregationStrategy {
+
+        @Override
+        public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+            if (oldExchange == null) {
+                return newExchange;
+            }
+            String body1 = oldExchange.getIn().getBody(String.class);
+            String body2 = newExchange.getIn().getBody(String.class);
+
+            oldExchange.getIn().setBody(body1 + body2);
+            return oldExchange;
+        }
+    }
+
+    @Override
+    public boolean consumerEnabled() {
+        return false;
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute
+                .setHeader("id", constant("id1"))
+                .setBody(constant("O"))
+                .to("direct:aggregate")
+                .log("sent O")
+                .setBody(constant("K"))
+                .to("direct:aggregate")
+                .log("sent K");
+
+        LevelDBAggregationRepository repo =
+                new LevelDBAggregationRepository("repo1",
+                        "%s/leveldb.dat".formatted(System.getProperty("project.target")));
+        repo.setSerializer(new JacksonLevelDBSerializer());
+
+        builder.from("direct:aggregate")
+                .id("aggregate route")
+                .aggregate(header("id"), new StringAggregationStrategy())
+                .completionSize(2)
+                .aggregationRepository(repo)
+                .toF("mock:%s", getResultMockName())
+                .end();
+    }
+}
+

--- a/tests/features/camel-leveldb/src/test/java/org/apache/karaf/camel/itest/CamelLeveldbITest.java
+++ b/tests/features/camel-leveldb/src/test/java/org/apache/karaf/camel/itest/CamelLeveldbITest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelLeveldbITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -75,6 +75,7 @@
         <module>camel-jetty</module>
         <module>camel-jms</module>
         <module>camel-kafka</module>
+        <module>camel-leveldb</module>
         <module>camel-netty-http</module>
         <module>camel-mail</module>
         <module>camel-olingo2</module>


### PR DESCRIPTION
Fixes #439 
Fix feature and add integration test.

Additional optional imports are necessary because the component call the classloader for those classes explicitely
In theory, only one of `leveldb` or `leveldbjni-all` dependency is necessary in the feature to provide a `DBFactory`