### PR TITLE
Repair camel-olingo2 integration test

### DIFF
--- a/tests/features/camel-olingo2/pom.xml
+++ b/tests/features/camel-olingo2/pom.xml
@@ -28,4 +28,30 @@
     <artifactId>camel-olingo2-test</artifactId>
     <name>Apache Camel :: Karaf :: Tests :: Features :: Olingo2</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${squareup-okhttp-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>olingo-odata2-api</artifactId>
+            <version>${olingo2-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta-ws-rs-api-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>olingo-odata2-core</artifactId>
+            <version>${olingo2-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/tests/features/camel-olingo2/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-olingo2/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -17,14 +17,13 @@
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
            xsi:schemaLocation="
              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
              http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint">
         <route id="testOlingo2Route-consumer">
-            <from uri="olingo2://read?resourcePath=Products&amp;serviceUri=http://services.odata.org/V2/Northwind/Northwind.svc"/>
+            <from uri="olingo2:DEFAULT/read?resourcePath=Manufacturers&amp;serviceUri=http://localhost:{{olingo.port}}/"/>
             <log message="Get message(consumer): ${body}"/>
             <setBody>
                 <constant>OK-Consumer</constant>
@@ -34,7 +33,7 @@
 
         <route id="testOlingo2Route-producer">
             <from uri="direct:camel-olingo2-test"/>
-            <to uri="olingo2://read?resourcePath=Employees&amp;serviceUri=http://services.odata.org/V2/Northwind/Northwind.svc"/>
+            <to uri="olingo2:DEFAULT/read?resourcePath=Manufacturers&amp;serviceUri=http://localhost:{{olingo.port}}/"/>
             <log message="Get message(producer): ${body}"/>
             <setBody>
                 <constant>OK-Producer</constant>

--- a/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/CamelOlingo2ITest.java
+++ b/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/CamelOlingo2ITest.java
@@ -16,15 +16,15 @@ package org.apache.karaf.camel.itest;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
 import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
 
-@CamelKarafTestHint(isBlueprintTest = true)
-@RunWith(PaxExam.class)
+@CamelKarafTestHint(isBlueprintTest = true, externalResourceProvider = CamelOlingo2ITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
 @ExamReactorStrategy(PerClass.class)
 public class CamelOlingo2ITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
 
@@ -36,6 +36,13 @@ public class CamelOlingo2ITest extends AbstractCamelSingleFeatureResultMockBased
     @Test
     public void testResultMock() throws Exception {
         assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        public static Olingo2Server createMockServer() {
+            return new Olingo2Server();
+        }
     }
 
 }

--- a/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/Olingo2Server.java
+++ b/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/Olingo2Server.java
@@ -1,0 +1,164 @@
+package org.apache.karaf.camel.itest;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.RuntimeCamelException;
+import org.apache.karaf.camel.itests.AvailablePortProvider;
+import org.apache.olingo.odata2.api.commons.HttpStatusCodes;
+import org.apache.olingo.odata2.api.commons.ODataHttpHeaders;
+import org.apache.olingo.odata2.api.edm.Edm;
+import org.apache.olingo.odata2.api.edm.EdmEntityContainer;
+import org.apache.olingo.odata2.api.edm.EdmEntitySet;
+import org.apache.olingo.odata2.api.edm.EdmEntityType;
+import org.apache.olingo.odata2.api.edm.EdmProperty;
+import org.apache.olingo.odata2.api.edm.EdmServiceMetadata;
+import org.apache.olingo.odata2.api.ep.EntityProvider;
+import org.apache.olingo.odata2.api.ep.EntityProviderWriteProperties;
+import org.apache.olingo.odata2.api.processor.ODataResponse;
+import org.apache.olingo.odata2.core.commons.ContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.ws.rs.HttpMethod;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+
+public class Olingo2Server extends AvailablePortProvider {
+
+    public static final Logger LOG = LoggerFactory.getLogger(Olingo2Server.class);
+    public static final String OLINGO_PORT = "olingo.port";
+
+    private static MockWebServer server;
+    private static Edm edm;
+    private static EdmEntitySet manufacturersSet;
+    private static final String MANUFACTURERS = "Manufacturers";
+    private static final String METADATA = "$metadata";
+    private static final String SERVICE_NAME = "MyFormula.svc";
+
+
+    public Olingo2Server() {
+        super(List.of(OLINGO_PORT));
+    }
+
+    @Override
+    public void before() {
+        super.before();
+        try {
+            initEdm();
+            initServer();
+        } catch (Exception e) {
+            LOG.error("cannot init EDM", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void after() {
+        try {
+            server.close();
+        } catch (IOException e) {
+            LOG.error("cannot close server EDM", e);
+        }
+        super.after();
+    }
+
+    private static void initEdm() throws Exception {
+        InputStream edmXml = Olingo2Server.class.getResourceAsStream("etag-enabled-service.xml");
+        edm = EntityProvider.readMetadata(edmXml, true);
+        assertNotNull(edm);
+
+        EdmEntityContainer entityContainer = edm.getDefaultEntityContainer();
+        assertNotNull(entityContainer);
+        manufacturersSet = entityContainer.getEntitySet(MANUFACTURERS);
+        assertNotNull(manufacturersSet);
+
+        EdmEntityType entityType = manufacturersSet.getEntityType();
+        assertNotNull(entityType);
+
+        //
+        // Check we have enabled eTag properties
+        //
+        EdmProperty property = (EdmProperty) entityType.getProperty("Id");
+        assertNotNull(property.getFacets());
+    }
+
+    private void initServer() throws Exception {
+        server = new MockWebServer();
+        server.setDispatcher(new Dispatcher() {
+
+            @SuppressWarnings("resource")
+            @Override
+            public MockResponse dispatch(RecordedRequest recordedRequest) {
+                MockResponse mockResponse = new MockResponse();
+
+                switch (recordedRequest.getMethod()) {
+                case HttpMethod.GET:
+                    try {
+                        if (recordedRequest.getPath().endsWith("/" + MANUFACTURERS)) {
+                            ODataResponse odataResponse = EntityProvider.writeFeed(ContentType.APPLICATION_JSON.toContentTypeString(),
+                                    manufacturersSet, List.of(getEntityData()),
+                                    EntityProviderWriteProperties.serviceRoot(getServiceUrl().uri()).build());
+                            InputStream entityStream = odataResponse.getEntityAsStream();
+                            mockResponse.setResponseCode(HttpStatusCodes.OK.getStatusCode());
+                            mockResponse.setBody(new Buffer().readFrom(entityStream));
+                            return mockResponse;
+                        } else if (recordedRequest.getPath().endsWith("/" + METADATA)) {
+                            EdmServiceMetadata serviceMetadata = edm.getServiceMetadata();
+                            return mockResponse.setResponseCode(HttpStatusCodes.OK.getStatusCode())
+                                    .addHeader(ODataHttpHeaders.DATASERVICEVERSION, serviceMetadata.getDataServiceVersion())
+                                    .setBody(new Buffer().readFrom(serviceMetadata.getMetadata()));
+                        }
+
+                    } catch (Exception ex) {
+                        throw new RuntimeCamelException(ex);
+                    }
+                    break;
+                case HttpMethod.PATCH:
+                case HttpMethod.PUT:
+                case HttpMethod.POST:
+                case HttpMethod.DELETE:
+                    return mockResponse.setResponseCode(HttpStatusCodes.NO_CONTENT.getStatusCode());
+                default:
+                    break;
+                }
+
+                mockResponse.setResponseCode(HttpStatusCodes.NOT_FOUND.getStatusCode()).setBody("{ status: \"Not Found\"}");
+                return mockResponse;
+            }
+        });
+        server.start(Integer.parseInt(super.properties().get(OLINGO_PORT)));
+    }
+
+    protected static Map<String, Object> getEntityData() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("Id", "123");
+        data.put("Name", "MyCarManufacturer");
+        data.put("Founded", new Date());
+        Map<String, Object> address = new HashMap<>();
+        address.put("Street", "Main");
+        address.put("ZipCode", "42421");
+        address.put("City", "Fairy City");
+        address.put("Country", "FarFarAway");
+        data.put("Address", address);
+        return data;
+    }
+
+    private static HttpUrl getServiceUrl() {
+        if (server == null) {
+            LOG.error("Test programming failure. Server not initialised");
+        }
+        return server.url(SERVICE_NAME);
+    }
+
+}

--- a/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/Olingo2Server.java
+++ b/tests/features/camel-olingo2/src/test/java/org/apache/karaf/camel/itest/Olingo2Server.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.karaf.camel.itest;
 
 import static org.junit.Assert.assertNotNull;

--- a/tests/features/camel-olingo2/src/test/resources/org/apache/karaf/camel/itest/etag-enabled-service.xml
+++ b/tests/features/camel-olingo2/src/test/resources/org/apache/karaf/camel/itest/etag-enabled-service.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" Version="1.0">
+    <script/>
+    <edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="1.0">
+        <Schema xmlns="http://schemas.microsoft.com/ado/2008/09/edm" Namespace="MyFormula">
+            <EntityType Name="Manufacturer">
+                <Key>
+                    <PropertyRef Name="Id"/>
+                </Key>
+                <!-- Includes concurrency support which is then handled using ETags -->
+                <Property Name="Id" Type="Edm.String" Nullable="true" ConcurrencyMode="Fixed"/>
+                <Property Name="Name" Type="Edm.String" Nullable="true" ConcurrencyMode="Fixed"/>
+                <Property Name="Founded" Type="Edm.DateTimeOffset" Nullable="true" ConcurrencyMode="Fixed"/>
+                <Property Name="Address" Type="MyFormula.Address" Nullable="true" ConcurrencyMode="Fixed"/>
+            </EntityType>
+            <ComplexType Name="Address">
+                <Property Name="Street" Type="Edm.String" Nullable="true"/>
+                <Property Name="City" Type="Edm.String" Nullable="true"/>
+                <Property Name="ZipCode" Type="Edm.String" Nullable="true"/>
+                <Property Name="Country" Type="Edm.String" Nullable="true"/>
+            </ComplexType>
+            <EntityContainer Name="DefaultContainer" m:IsDefaultEntityContainer="true">
+                <EntitySet Name="Manufacturers" EntityType="MyFormula.Manufacturer"/>
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -84,8 +84,7 @@
         <module>camel-leveldb</module>
         <module>camel-netty-http</module>
         <module>camel-mail</module>
-        <!-- TODO: Fix the integration test and re-add it https://github.com/apache/camel-karaf/issues/472 -->
-        <!--module>camel-olingo2</module-->
+        <module>camel-olingo2</module>
         <module>camel-paho-mqtt5</module>
         <module>camel-quartz</module>
         <module>camel-saxon</module>


### PR DESCRIPTION
Fixes #472 
Instead of using the public url http://services.odata.org/V2/Northwind/Northwind.svc , create a mock server like in the camel project to serve olingo2 requests