### PR TITLE
Fix integration tests camel route suppliers service declaration

### DIFF
--- a/tests/features/camel-atom/src/main/java/org/apache/karaf/camel/test/CamelAtomRouteSupplier.java
+++ b/tests/features/camel-atom/src/main/java/org/apache/karaf/camel/test/CamelAtomRouteSupplier.java
@@ -20,12 +20,13 @@ import java.util.function.Function;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-atom-test",
         immediate = true,
-        service = CamelAtomRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelAtomRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-avro/src/main/java/org/apache/karaf/camel/test/CamelAvroRouteSupplier.java
+++ b/tests/features/camel-avro/src/main/java/org/apache/karaf/camel/test/CamelAvroRouteSupplier.java
@@ -24,13 +24,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.dataformat.avro.AvroDataFormat;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 
 @Component(
         name = "karaf-camel-avro-test",
         immediate = true,
-        service = CamelAvroRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelAvroRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-barcode/src/main/java/org/apache/karaf/camel/test/CamelBarcodeRouteSupplier.java
+++ b/tests/features/camel-barcode/src/main/java/org/apache/karaf/camel/test/CamelBarcodeRouteSupplier.java
@@ -35,6 +35,7 @@ import org.apache.camel.dataformat.barcode.BarcodeImageType;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.spi.DataFormat;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 import com.google.zxing.BarcodeFormat;
@@ -47,7 +48,7 @@ import com.google.zxing.common.HybridBinarizer;
 @Component(
         name = "karaf-camel-barcode-test",
         immediate = true,
-        service = CamelBarcodeRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelBarcodeRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
+++ b/tests/features/camel-bean-validator/src/main/java/org/apache/karaf/camel/test/CamelBeanValidatorRouteSupplier.java
@@ -20,6 +20,7 @@ import static org.apache.camel.builder.Builder.constant;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 import jakarta.validation.constraints.Min;
@@ -28,7 +29,7 @@ import jakarta.validation.constraints.NotNull;
 @Component(
         name = "karaf-camel-bean-validator-test",
         immediate = true,
-        service = CamelBeanValidatorRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelBeanValidatorRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-bindy/src/main/java/org/apache/karaf/camel/test/CamelBindyRouteSupplier.java
+++ b/tests/features/camel-bindy/src/main/java/org/apache/karaf/camel/test/CamelBindyRouteSupplier.java
@@ -19,12 +19,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.dataformat.bindy.csv.BindyCsvDataFormat;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-bindy-test",
         immediate = true,
-        service = CamelBindyRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelBindyRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-caffeine/src/main/java/org/apache/karaf/camel/test/CamelCaffeineRouteSupplier.java
+++ b/tests/features/camel-caffeine/src/main/java/org/apache/karaf/camel/test/CamelCaffeineRouteSupplier.java
@@ -21,12 +21,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.caffeine.CaffeineConstants;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-caffeine-test",
         immediate = true,
-        service = CamelCaffeineRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCaffeineRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-cbor/src/main/java/org/apache/karaf/camel/test/CamelCborRouteSupplier.java
+++ b/tests/features/camel-cbor/src/main/java/org/apache/karaf/camel/test/CamelCborRouteSupplier.java
@@ -24,12 +24,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cbor.CBORDataFormat;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-cbor-test",
         immediate = true,
-        service = CamelCborRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCborRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-chatscript/src/main/java/org/apache/karaf/camel/test/CamelChatscriptRouteSupplier.java
+++ b/tests/features/camel-chatscript/src/main/java/org/apache/karaf/camel/test/CamelChatscriptRouteSupplier.java
@@ -20,6 +20,7 @@ import org.apache.camel.component.chatscript.ChatScriptMessage;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.language.SimpleExpression;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Component(
         name = "karaf-camel-chatscript-test",
         immediate = true,
-        service = CamelChatscriptRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelChatscriptRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-coap/src/main/java/org/apache/karaf/camel/test/CamelCoapRouteSupplier.java
+++ b/tests/features/camel-coap/src/main/java/org/apache/karaf/camel/test/CamelCoapRouteSupplier.java
@@ -22,12 +22,13 @@ import java.util.function.Function;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-coap-test",
         immediate = true,
-        service = CamelCoapRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCoapRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-consul/src/main/java/org/apache/karaf/camel/test/CamelConsulRouteSupplier.java
+++ b/tests/features/camel-consul/src/main/java/org/apache/karaf/camel/test/CamelConsulRouteSupplier.java
@@ -26,12 +26,13 @@ import org.apache.camel.component.consul.endpoint.ConsulHealthActions;
 import org.apache.camel.component.consul.endpoint.ConsulKeyValueActions;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-consul-test",
         immediate = true,
-        service = CamelConsulRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelConsulRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-couchdb/src/main/java/org/apache/karaf/camel/test/CamelCouchdbRouteSupplier.java
+++ b/tests/features/camel-couchdb/src/main/java/org/apache/karaf/camel/test/CamelCouchdbRouteSupplier.java
@@ -24,12 +24,13 @@ import org.apache.camel.component.couchdb.CouchDbConstants;
 import org.apache.camel.component.couchdb.CouchDbOperations;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-couchdb-test",
         immediate = true,
-        service = CamelCouchdbRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCouchdbRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-crypto/src/main/java/org/apache/karaf/camel/test/CamelCryptoRouteSupplier.java
+++ b/tests/features/camel-crypto/src/main/java/org/apache/karaf/camel/test/CamelCryptoRouteSupplier.java
@@ -26,12 +26,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.crypto.DigitalSignatureConstants;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-crypto-test",
         immediate = true,
-        service = CamelCryptoRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCryptoRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-csv/src/main/java/org/apache/karaf/camel/test/CamelCsvRouteSupplier.java
+++ b/tests/features/camel-csv/src/main/java/org/apache/karaf/camel/test/CamelCsvRouteSupplier.java
@@ -19,12 +19,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.dataformat.CsvDataFormat;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-csv-test",
         immediate = true,
-        service = CamelCsvRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelCsvRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-exec/src/main/java/org/apache/karaf/camel/test/CamelExecRouteSupplier.java
+++ b/tests/features/camel-exec/src/main/java/org/apache/karaf/camel/test/CamelExecRouteSupplier.java
@@ -18,12 +18,13 @@ package org.apache.karaf.camel.test;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-exec-test",
         immediate = true,
-        service = CamelExecRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelExecRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-flatpack/src/main/java/org/apache/karaf/camel/test/CamelFlatpackRouteSupplier.java
+++ b/tests/features/camel-flatpack/src/main/java/org/apache/karaf/camel/test/CamelFlatpackRouteSupplier.java
@@ -21,12 +21,13 @@ import java.util.function.Function;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-flatpack-test",
         immediate = true,
-        service = CamelFlatpackRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelFlatpackRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tests/features/camel-leveldb/src/main/java/org/apache/karaf/camel/test/CamelLeveldbRouteSupplier.java
+++ b/tests/features/camel-leveldb/src/main/java/org/apache/karaf/camel/test/CamelLeveldbRouteSupplier.java
@@ -25,12 +25,13 @@ import org.apache.camel.component.leveldb.LevelDBAggregationRepository;
 import org.apache.camel.component.leveldb.serializer.JacksonLevelDBSerializer;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-leveldb-test",
         immediate = true,
-        service = CamelLeveldbRouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class CamelLeveldbRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 

--- a/tooling/camel-karaf-test-feature-archetype/src/main/resources/archetype-resources/src/main/java/test/Camel__featureName__RouteSupplier.java
+++ b/tooling/camel-karaf-test-feature-archetype/src/main/resources/archetype-resources/src/main/java/test/Camel__featureName__RouteSupplier.java
@@ -22,12 +22,13 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
 
 @Component(
         name = "karaf-camel-${featureNameLower}-test",
         immediate = true,
-        service = Camel${featureName}RouteSupplier.class
+        service = CamelRouteSupplier.class
 )
 public class Camel${featureName}RouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
 


### PR DESCRIPTION
Fixes https://github.com/apache/camel-karaf/issues/508: change the camel route suppliers service declaration to `CamelRouteSupplier.class` in:
```
camel-atom-test
camel-avro-test
camel-barcode-test
camel-bean-validator-test
camel-bindy-test
camel-caffeine-test
camel-cbor-test
camel-chatscript-test
camel-coap-test
camel-consul-test
camel-couchdb-test
camel-crypto-test
camel-csv-test
camel-exec-test
camel-flatpack-test
camel-leveldb-test
```