### PR TITLE
Ref #430: Bump apache pom from 31 to 33

### DIFF
--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -75,7 +75,7 @@
                         </Import-Package>
                         <Provide-Capability>
                             osgi.extender; osgi.extender="org.apache.camel"; uses:="org.apache.camel.karaf.core";
-                            version:Version="$(version;==;4.5.0)"
+                            version:Version="$(version;==;${camel-version})"
                         </Provide-Capability>
                         <Bundle-Activator>org.apache.camel.karaf.core.Activator</Bundle-Activator>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>31</version>
+        <version>33</version>
     </parent>
 
     <groupId>org.apache.camel.karaf</groupId>
@@ -88,6 +88,8 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <jdk-version>17</jdk-version>
+        <maven.compiler.source>${jdk-version}</maven.compiler.source>
+        <maven.compiler.target>${jdk-version}</maven.compiler.target>
 
         <camel-version>4.8.0</camel-version>
 
@@ -706,10 +708,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin-version}</version>
-                <configuration>
-                    <source>${jdk-version}</source>
-                    <target>${jdk-version}</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
fixes #430 

## Motivation

The latest version of the Apache Pom is 33, we would like to upgrade it

## Modifications:

* Bump Apache Pom from 31 to 33
* Configure the maven compiler plugin using properties as it is parent pom relies on them to configure the plugin
* No longer hard code the version in camel-core-osgi (not related to the initial issue)