### PR TITLE
Ref #495: Skip LevelDB test for AArch64

### DIFF
--- a/tests/features/camel-leveldb/pom.xml
+++ b/tests/features/camel-leveldb/pom.xml
@@ -37,4 +37,25 @@
             <version>${camel-version}</version>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>disable-test-for-unsupported-architectures</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
fixes #495 

## Motivation

The integration test for LevelDB fails on architecture AArch64

## Modifications:

* Disable the test for architecture AArch64, as it is not supported by the underlying library