### PR TITLE
Ref #441: Exclude pax-logging-logback

### DIFF
--- a/tests/examples/pom.xml
+++ b/tests/examples/pom.xml
@@ -120,6 +120,10 @@
                     <groupId>org.apache.karaf</groupId>
                     <artifactId>org.apache.karaf.client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-logback</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Required to use shell commands in the tests -->

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -186,6 +186,10 @@
                     <groupId>org.apache.karaf</groupId>
                     <artifactId>org.apache.karaf.client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-logback</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Required to use shell commands in the tests -->


### PR DESCRIPTION
fixes #441 

## Motivation

We have a warning in the integration tests indicating that we have too many SLF4J providers in the classpath.

## Modifications

* Exclude pax-logging-logback