### PR TITLE
Ref #451: Allow to clean up integration tests

### DIFF
--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelRouteSupplier.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelRouteSupplier.java
@@ -23,4 +23,11 @@ public interface CamelRouteSupplier {
      * @param builder the Camel route builder
      */
     void createRoutes(RouteBuilder builder);
+
+    /**
+     * Cleans up the Camel context before removing the routes.
+     */
+    default void cleanUp(CamelContext camelContext) {
+        // Do nothing by default
+    }
 }

--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelSuppliedRouteLauncher.java
@@ -124,6 +124,7 @@ public class CamelSuppliedRouteLauncher extends AbstractCamelRouteLauncher imple
                 return;
             }
             camelContext.removeRouteDefinitions(routeDefinitions);
+            supplier.cleanUp(camelContext);
             LOG.info("Route(s) removed from CamelRouteSupplier service: {}", supplier.getClass().getName());
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/tests/features/camel-arangodb/src/main/java/org/apache/karaf/camel/test/CamelArangodbRouteSupplier.java
+++ b/tests/features/camel-arangodb/src/main/java/org/apache/karaf/camel/test/CamelArangodbRouteSupplier.java
@@ -42,7 +42,7 @@ public class CamelArangodbRouteSupplier extends AbstractCamelSingleFeatureResult
 
     @Override
     public void configure(CamelContext camelContext) {
-        final int arangoPort = Integer.parseInt(System.getProperty("arango.port"));
+        final int arangoPort = Integer.getInteger("arango.port");
         ArangoDB arangoDb = new ArangoDB.Builder().host("localhost", arangoPort).build();
 
         arangoDb.createDatabase(DATABASE_NAME);
@@ -54,7 +54,14 @@ public class CamelArangodbRouteSupplier extends AbstractCamelSingleFeatureResult
         arangoDbComponent.getConfiguration().setHost("localhost");
         arangoDbComponent.getConfiguration().setPort(arangoPort);
 
-        camelContext.addComponent("arangodb",arangoDbComponent);
+        camelContext.addComponent("arangodb", arangoDbComponent);
+    }
+
+    @Override
+    public void cleanUp(CamelContext camelContext) {
+        if (camelContext.hasComponent("arangodb") instanceof ArangoDbComponent arangoDbComponent) {
+            arangoDbComponent.getArangoDB().shutdown();
+        }
     }
 
     @Override

--- a/tests/features/camel-as2/src/main/java/org/apache/karaf/camel/test/CamelAs2RouteSupplier.java
+++ b/tests/features/camel-as2/src/main/java/org/apache/karaf/camel/test/CamelAs2RouteSupplier.java
@@ -75,7 +75,7 @@ public class CamelAs2RouteSupplier extends AbstractCamelSingleFeatureResultMockB
 
     @Override
     public void configure(CamelContext context) {
-        final int port = Integer.parseInt(System.getProperty("as2.port"));
+        final int port = Integer.getInteger("as2.port");
         final AS2Configuration configuration = new AS2Configuration();
         configuration.setTargetHostname("localhost");
         configuration.setTargetPortNumber(port);

--- a/tests/features/camel-dns/pom.xml
+++ b/tests/features/camel-dns/pom.xml
@@ -35,7 +35,6 @@
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
             <version>${dnsjava-version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-dns/src/main/java/org/apache/karaf/camel/test/CamelDnsRouteSupplier.java
+++ b/tests/features/camel-dns/src/main/java/org/apache/karaf/camel/test/CamelDnsRouteSupplier.java
@@ -15,11 +15,13 @@
  */
 package org.apache.karaf.camel.test;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
 import org.apache.karaf.camel.itests.CamelRouteSupplier;
 import org.osgi.service.component.annotations.Component;
+import org.xbill.DNS.NioClient;
 
 @Component(
         name = "karaf-camel-dns-test",
@@ -33,6 +35,12 @@ public class CamelDnsRouteSupplier extends AbstractCamelSingleFeatureResultMockB
     @Override
     protected boolean consumerEnabled() {
         return false;
+    }
+
+    @Override
+    public void cleanUp(CamelContext camelContext) {
+        // Close it explicitly to prevent NoClassDefFoundError after the test
+        NioClient.close();
     }
 
     @Override

--- a/tests/features/camel-ehcache/src/main/java/org/apache/karaf/camel/test/CamelEhcacheRouteSupplier.java
+++ b/tests/features/camel-ehcache/src/main/java/org/apache/karaf/camel/test/CamelEhcacheRouteSupplier.java
@@ -51,7 +51,16 @@ public class CamelEhcacheRouteSupplier extends AbstractCamelSingleFeatureResultM
                 )
                 .build(true);
 
-        camelContext.getRegistry().bind("cacheManager",cacheManager);
+        camelContext.getRegistry().bind("cacheManager", cacheManager);
+    }
+
+    @Override
+    public void cleanUp(CamelContext camelContext) {
+        CacheManager cacheManager = camelContext.getRegistry().lookupByNameAndType("cacheManager", CacheManager.class);
+        if (cacheManager == null) {
+            return;
+        }
+        cacheManager.close();
     }
 
     @Override

--- a/tests/features/camel-elasticsearch/src/main/java/org/apache/karaf/camel/test/CamelElasticsearchRouteSupplier.java
+++ b/tests/features/camel-elasticsearch/src/main/java/org/apache/karaf/camel/test/CamelElasticsearchRouteSupplier.java
@@ -39,7 +39,7 @@ public class CamelElasticsearchRouteSupplier extends AbstractCamelSingleFeatureR
         elasticsearchComponent.setPassword(System.getProperty("elasticsearch.password"));
         elasticsearchComponent.setCertificatePath("file:%s".formatted(System.getProperty("elasticsearch.cafile")));
 
-        camelContext.addComponent("elasticsearch",elasticsearchComponent);
+        camelContext.addComponent("elasticsearch", elasticsearchComponent);
     }
 
     @Override

--- a/tests/features/camel-hazelcast/src/main/java/org/apache/karaf/camel/test/CamelHazelcastRouteSupplier.java
+++ b/tests/features/camel-hazelcast/src/main/java/org/apache/karaf/camel/test/CamelHazelcastRouteSupplier.java
@@ -36,10 +36,18 @@ public class CamelHazelcastRouteSupplier extends AbstractCamelSingleFeatureResul
 
     @Override
     public void configure(CamelContext camelContext) {
-        ClusterProperty.SHUTDOWNHOOK_ENABLED.setSystemProperty("false");
         Config hazelcastConfig = new Config();
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(hazelcastConfig);
         camelContext.getRegistry().bind("hzInstance", hazelcastInstance);
+    }
+
+    @Override
+    public void cleanUp(CamelContext camelContext) {
+        HazelcastInstance hazelcastInstance = camelContext.getRegistry().lookupByNameAndType("hzInstance", HazelcastInstance.class);
+        if (hazelcastInstance == null) {
+            return;
+        }
+        hazelcastInstance.shutdown();
     }
 
     @Override

--- a/tests/features/camel-influxdb2/src/main/java/org/apache/karaf/camel/test/CamelInfluxdb2RouteSupplier.java
+++ b/tests/features/camel-influxdb2/src/main/java/org/apache/karaf/camel/test/CamelInfluxdb2RouteSupplier.java
@@ -38,11 +38,20 @@ public class CamelInfluxdb2RouteSupplier extends AbstractCamelSingleFeatureResul
 
     @Override
     public void configure(CamelContext camelContext) {
-        final int influxdb2Port = Integer.parseInt(System.getProperty("influxdb2.port"));
-        InfluxDBClient myInfluxDBClient = InfluxDBClientFactory.create("http://localhost:%s".formatted(influxdb2Port),
+        final int influxdb2Port = Integer.getInteger("influxdb2.port");
+        InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:%s".formatted(influxdb2Port),
                 System.getProperty("influxdb2.admin.token").toCharArray(), ORG, BUCKET);
 
-        camelContext.getRegistry().bind("myDbClient", myInfluxDBClient);
+        camelContext.getRegistry().bind("myDbClient", influxDBClient);
+    }
+
+    @Override
+    public void cleanUp(CamelContext camelContext) {
+        InfluxDBClient influxDBClient = camelContext.getRegistry().lookupByNameAndType("myDbClient", InfluxDBClient.class);
+        if (influxDBClient == null) {
+            return;
+        }
+        influxDBClient.close();
     }
 
     @Override

--- a/tests/features/camel-netty-http/src/main/java/org/apache/karaf/camel/test/CamelRestNettyHttpRouteSupplier.java
+++ b/tests/features/camel-netty-http/src/main/java/org/apache/karaf/camel/test/CamelRestNettyHttpRouteSupplier.java
@@ -34,7 +34,7 @@ public class CamelRestNettyHttpRouteSupplier extends AbstractCamelSingleFeatureR
         RestConfiguration config = new RestConfiguration();
         config.setComponent("netty-http");
         config.setHost("127.0.0.1");
-        config.setPort(Integer.parseInt(System.getProperty(REST_PORT)));
+        config.setPort(Integer.getInteger(REST_PORT));
         camelContext.setRestConfiguration(config);
     }
 


### PR DESCRIPTION
fixes #451 

## Motivation

There are some integration tests where we get `NoClassDefFoundError` after the test execution.

## Modifications:

* Allow to clean up integration tests to prevent side effects  `NoClassDefFoundError` after the execution of the tests
* Implement a clean-up for all integration tests that need it