### PR TITLE
Ref #530: Add camel-debezium-postgres integration test

### DIFF
--- a/components/camel-debezium/camel-debezium-postgres/pom.xml
+++ b/components/camel-debezium/camel-debezium-postgres/pom.xml
@@ -53,6 +53,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Must be removed once the split package issue is fixed in Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,6 +81,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!-- Must be removed once the split package issue is fixed in Camel -->
+                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-postgres</include>
                                 </includes>
                             </artifactSet>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -920,12 +920,20 @@
     </feature>
     <feature name='camel-debezium-common' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-api/${kafka-version}</bundle>
+        <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-afterburner/${jackson216-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/kafka-clients/${kafka-version}</bundle>
+        <!-- Api, runtime and transform have split packages so we merge all into api -->
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-runtime/${kafka-version}$Fragment-Host=org.apache.kafka.connect-api;bundle-version=${kafka-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-transforms/${kafka-version}$Fragment-Host=org.apache.kafka.connect-api;bundle-version=${kafka-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-api/${kafka-version}$Bundle-SymbolicName=org.apache.kafka.connect-api</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-file/${kafka-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.kafka/connect-json/${kafka-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-api/${debezium-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-api/${debezium-version}$${spi-consumer}</bundle>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-embedded/${debezium-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-core/${debezium-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-core/${debezium-version}$DynamicImport-Package=io.debezium.connector.*&amp;${spi-consumer}</bundle>
+        <!-- Uncomment when the split package issue is fixed in Camel -->
+        <!--<bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>-->
     </feature>
     <feature name='camel-debezium-db2' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
@@ -950,6 +958,8 @@
     <feature name='camel-debezium-postgres' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-postgres/${debezium-version}</bundle>
+        <bundle dependency='true'>mvn:org.postgresql/postgresql/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-postgres/${project.version}</bundle>
     </feature>
     <feature name='camel-debezium-sqlserver' version='${project.version}' start-level='50'>

--- a/tests/features/camel-debezium-postgres/pom.xml
+++ b/tests/features/camel-debezium-postgres/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-debezium-postgres-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Debezium PostgreSQL</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-postgres</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-sql</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-debezium-postgres/src/main/java/org/apache/karaf/camel/test/CamelDebeziumPostgresRouteSupplier.java
+++ b/tests/features/camel-debezium-postgres/src/main/java/org/apache/karaf/camel/test/CamelDebeziumPostgresRouteSupplier.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import static org.apache.camel.builder.Builder.constant;
+
+import java.util.function.Function;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.sql.SqlComponent;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+import org.postgresql.ds.PGSimpleDataSource;
+
+@Component(
+        name = "karaf-camel-debezium-postgres-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelDebeziumPostgresRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    @Override
+    public void configure(CamelContext context) {
+        PGSimpleDataSource db = new PGSimpleDataSource();
+        db.setServerNames(new String[]{System.getProperty("pgsql.host")});
+        db.setPortNumbers(new int[]{Integer.getInteger("pgsql.port")});
+        db.setUser(System.getProperty("pgsql.username"));
+        db.setPassword(System.getProperty("pgsql.password"));
+        db.setDatabaseName(System.getProperty("pgsql.database"));
+
+        context.getComponent("sql", SqlComponent.class).setDataSource(db);
+    }
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder ->
+                builder.fromF("debezium-postgres:debezium-postgres-example-01?databaseHostname=%s&databasePort=%s"
+                                + "&databaseUser=%s&databasePassword=%s&databaseDbname=%s"
+                                + "&topicPrefix=embedded-debezium&offsetStorageFileName=offset-01.data&pluginName=pgoutput"
+                                + "&schemaIncludeList=%s&tableIncludeList=%s",
+                                System.getProperty("pgsql.host"), System.getProperty("pgsql.port"),
+                                System.getProperty("pgsql.username"), System.getProperty("pgsql.password"),
+                                System.getProperty("pgsql.database"), System.getProperty("pgsql.schema"), System.getProperty("pgsql.table"))
+                        .log("received message ${body}")
+                        .process(exchange -> exchange.getIn().setBody(exchange.getIn().getBody(Struct.class).get("id")));
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute
+                .log("insert new product")
+                .setBody(constant(new Object[] { 1, "scooter", "Small 2-wheel yellow scooter", 5.54 }))
+                .toF("sql:insert into %s (id, name, description, weight) values (#, #, #, #)", System.getProperty("pgsql.table"));
+    }
+}
+

--- a/tests/features/camel-debezium-postgres/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumPostgresITest.java
+++ b/tests/features/camel-debezium-postgres/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumPostgresITest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
+
+@CamelKarafTestHint(externalResourceProvider = CamelDebeziumPostgresITest.ExternalResourceProviders.class,
+        additionalRequiredFeatures = "camel-sql")
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelDebeziumPostgresITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("101", "102", "103", "104", "105", "106", "107", "108", "109", "1");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final String SOURCE_DB_SCHEMA = "inventory";
+        private static final String SOURCE_DB_TABLE = String.format("%s.products", SOURCE_DB_SCHEMA);
+        private static final String DEBEZIUM_VERSION = "2.7";
+        private static final String PGSQL_IMAGE = "quay.io/debezium/example-postgres";
+        private static final String SOURCE_DB_NAME = "debezium-db";
+        private static final String SOURCE_DB_USERNAME = "debezium";
+        private static final String SOURCE_DB_PASSWORD = "dbz";
+
+        public static GenericContainerResource<PGSQLContainer> createPGSQLContainer() {
+
+            PGSQLContainer container = new PGSQLContainer(DockerImageName.parse(PGSQL_IMAGE).withTag(DEBEZIUM_VERSION)
+                    .asCompatibleSubstituteFor("postgres"))
+                    .withDatabaseName(SOURCE_DB_NAME)
+                    .withUsername(SOURCE_DB_USERNAME)
+                    .withPassword(SOURCE_DB_PASSWORD);
+            return new GenericContainerResource<>(container,
+                    resource -> {
+                        resource.setProperty("pgsql.host", container.getHost());
+                        resource.setProperty("pgsql.port", Integer.toString(container.getMappedPort(POSTGRESQL_PORT)));
+                        resource.setProperty("pgsql.schema", SOURCE_DB_SCHEMA);
+                        resource.setProperty("pgsql.table", SOURCE_DB_TABLE);
+                        resource.setProperty("pgsql.database", container.getDatabaseName());
+                        resource.setProperty("pgsql.username", container.getUsername());
+                        resource.setProperty("pgsql.password", container.getPassword());
+                    }
+            );
+        }
+    }
+
+    private static class PGSQLContainer extends PostgreSQLContainer<PGSQLContainer> {
+        public PGSQLContainer(DockerImageName dockerImageName) {
+            super(dockerImageName);
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -68,6 +68,7 @@
         <module>camel-crypto</module>
         <module>camel-csv</module>
         <module>camel-cxf</module>
+        <module>camel-debezium-postgres</module>
         <module>camel-disruptor</module>
         <module>camel-dns</module>
         <module>camel-docker</module>


### PR DESCRIPTION
fixes #530 

## Motivation

Debezium features don't work so we need an integration test to ensure that they work as expected

## Modifications:

* Add missing dependencies to the feature `camel-debezium-common` and `camel-debezium-postgres`
* Add a workaround for the split package issue in Camel
* Add an integration test