### PR TITLE
Ref #531: Add camel-debezium-mysql integration test

### DIFF
--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -53,6 +53,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Must be removed once the split package issue is fixed in Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,6 +81,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!-- Must be removed once the split package issue is fixed in Camel -->
+                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-mysql</include>
                                 </includes>
                             </artifactSet>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -932,6 +932,7 @@
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-api/${debezium-version}$${spi-consumer}</bundle>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-embedded/${debezium-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-core/${debezium-version}$DynamicImport-Package=io.debezium.connector.*&amp;${spi-consumer}</bundle>
+        <bundle>wrap:mvn:io.debezium/debezium-storage-file/${debezium-version}</bundle>
         <!-- Uncomment when the split package issue is fixed in Camel -->
         <!--<bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>-->
     </feature>
@@ -948,6 +949,13 @@
     <feature name='camel-debezium-mysql' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-mysql/${debezium-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-binlog/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-ddl-parser/${auto-detect-version}</bundle>
+        <!-- Use the wrap protocol to make org.antlr.v4.gui optional-->
+        <bundle>wrap:mvn:org.antlr/antlr4-runtime/${auto-detect-version}$overwrite=merge&amp;Import-Package=org.antlr.v4.gui*;resolution:=optional,*</bundle>
+        <bundle>wrap:mvn:io.debezium/debezium-storage-kafka/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.zendesk/mysql-binlog-connector-java/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.mysql/mysql-connector-j/${debezium-mysql-connector-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-mysql/${project.version}</bundle>
     </feature>
     <feature name='camel-debezium-oracle' version='${project.version}' start-level='50'>

--- a/tests/features/camel-debezium-mysql/pom.xml
+++ b/tests/features/camel-debezium-mysql/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-debezium-mysql-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Debezium MySQL</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${debezium-mysql-connector-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-mysql</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-sql</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-debezium-mysql/src/main/java/org/apache/karaf/camel/test/CamelDebeziumMysqlRouteSupplier.java
+++ b/tests/features/camel-debezium-mysql/src/main/java/org/apache/karaf/camel/test/CamelDebeziumMysqlRouteSupplier.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import java.util.function.Function;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.sql.SqlComponent;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import static org.apache.camel.builder.Builder.constant;
+import static org.apache.camel.builder.Builder.simple;
+
+@Component(
+        name = "karaf-camel-debezium-mysql-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelDebeziumMysqlRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    @Override
+    public void configure(CamelContext context) {
+        MysqlDataSource db = new MysqlDataSource();
+        db.setServerName(System.getProperty("mysql.host"));
+        db.setPort(Integer.getInteger("mysql.port"));
+        db.setDatabaseName(System.getProperty("mysql.database"));
+        db.setUser(System.getProperty("mysql.username"));
+        db.setPassword(System.getProperty("mysql.password"));
+
+        context.getComponent("sql", SqlComponent.class).setDataSource(db);
+    }
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder ->
+                (RouteDefinition) builder.fromF("debezium-mysql:debezium-mysql-example-01?databaseHostname=%s&databasePort=%s"
+                                + "&databaseUser=%s&databasePassword=%s"
+                                + "&topicPrefix=embedded-debezium&offsetStorageFileName=offset-01.data&offsetStorage=org.apache.kafka.connect.storage.FileOffsetBackingStore"
+                                + "&databaseIncludeList=%s&tableIncludeList=%s&databaseServerId=184054&schemaHistoryInternal=io.debezium.storage.file.history.FileSchemaHistory&schemaHistoryInternalFileFilename=schema-history-01.data",
+                                System.getProperty("mysql.host"), System.getProperty("mysql.port"),
+                                System.getProperty("mysql.username"), System.getProperty("mysql.password"),
+                                System.getProperty("mysql.database"), System.getProperty("mysql.table"))
+                        .log("received message ${body}")
+                        .choice()
+                            .when(simple("${body.toString} contains 'id'"))
+                                .process(exchange -> exchange.getIn().setBody(exchange.getIn().getBody(Struct.class).get("id")))
+                            .otherwise()
+                                .stop()
+                        .endChoice()
+                        .end();
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute
+                .log("insert new product")
+                .setBody(constant(new Object[] { 1, "scooter", "Small 2-wheel yellow scooter", 5.54 }))
+                .toF("sql:insert into %s (id, name, description, weight) values (#, #, #, #)", System.getProperty("mysql.table"));
+    }
+}
+

--- a/tests/features/camel-debezium-mysql/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumMysqlITest.java
+++ b/tests/features/camel-debezium-mysql/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumMysqlITest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
+
+@CamelKarafTestHint(externalResourceProvider = CamelDebeziumMysqlITest.ExternalResourceProviders.class,
+        additionalRequiredFeatures = "camel-sql")
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelDebeziumMysqlITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceivedInAnyOrder("101", "102", "103", "104", "105", "106", "107", "108", "109", "1");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final String DEBEZIUM_VERSION = "2.7";
+        private static final String MYSQL_IMAGE = "quay.io/debezium/example-mysql";
+        private static final String SOURCE_DB_NAME = "inventory";
+        private static final String SOURCE_DB_TABLE = String.format("%s.products", SOURCE_DB_NAME);
+        private static final String SOURCE_DB_USERNAME = "mysqluser";
+        private static final String SOURCE_DB_PASSWORD = "dbz";
+
+        public static GenericContainerResource<MYSQLContainer> createMySQLContainer() {
+
+            MYSQLContainer container = new MYSQLContainer(DockerImageName.parse(MYSQL_IMAGE).withTag(DEBEZIUM_VERSION)
+                    .asCompatibleSubstituteFor("mysql"))
+                    .withUsername(SOURCE_DB_USERNAME)
+                    .withPassword(SOURCE_DB_PASSWORD);
+            return new GenericContainerResource<>(container,
+                    resource -> {
+                        resource.setProperty("mysql.host", container.getHost());
+                        resource.setProperty("mysql.port", Integer.toString(container.getMappedPort(MYSQL_PORT)));
+                        resource.setProperty("mysql.table", SOURCE_DB_TABLE);
+                        resource.setProperty("mysql.database", SOURCE_DB_NAME);
+                        // Need root access to avoid permission issues
+                        resource.setProperty("mysql.username", "root");
+                        resource.setProperty("mysql.password", container.getPassword());
+                    }
+            );
+        }
+    }
+
+    private static class MYSQLContainer extends MySQLContainer<MYSQLContainer> {
+        public MYSQLContainer(DockerImageName dockerImageName) {
+            super(dockerImageName);
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -68,6 +68,7 @@
         <module>camel-crypto</module>
         <module>camel-csv</module>
         <module>camel-cxf</module>
+        <module>camel-debezium-mysql</module>
         <module>camel-debezium-postgres</module>
         <module>camel-disruptor</module>
         <module>camel-dns</module>


### PR DESCRIPTION
fixes #531 

## Motivation

Debezium features don't work so we need an integration test to ensure that they work as expected

## Modifications:

* Add missing dependencies to the feature `camel-debezium-common` and `camel-debezium-mysql`
* Add a workaround for the split package issue in Camel
* Add an integration test