### PR TITLE
Ref #534: Remove docker images on exit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+            /opt/ghc \
+            "/usr/local/share/boost" \
+            "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:

--- a/tests/examples/pom.xml
+++ b/tests/examples/pom.xml
@@ -234,7 +234,7 @@
                                 <project.target>${project.build.directory}</project.target>
                                 <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
                             </systemPropertyVariables>
-                            <forkedProcessExitTimeoutInSeconds>5</forkedProcessExitTimeoutInSeconds>
+                            <forkedProcessExitTimeoutInSeconds>10</forkedProcessExitTimeoutInSeconds>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/features/camel-cxf/pom.xml
+++ b/tests/features/camel-cxf/pom.xml
@@ -84,7 +84,7 @@
                                 <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
                                 <cxf.version>${cxf-version}</cxf.version>
                             </systemPropertyVariables>
-                            <forkedProcessExitTimeoutInSeconds>5</forkedProcessExitTimeoutInSeconds>
+                            <forkedProcessExitTimeoutInSeconds>10</forkedProcessExitTimeoutInSeconds>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <dump.logs.on.failure>false</dump.logs.on.failure>
+        <keep.docker.images.on.exit>false</keep.docker.images.on.exit>
         <users.file.location>${project.basedir}/../../camel-integration-test/src/main/resources/etc/users.properties</users.file.location>
     </properties>
 
@@ -298,13 +299,14 @@
                             </includes>
                             <systemPropertyVariables>
                                 <camel.karaf.itest.dump.logs>${dump.logs.on.failure}</camel.karaf.itest.dump.logs>
+                                <camel.karaf.itest.keep.docker.images>${keep.docker.images.on.exit}</camel.karaf.itest.keep.docker.images>
                                 <camel.karaf.version>${project.version}</camel.karaf.version>
                                 <project.version>${project.version}</project.version>
                                 <project.target>${project.build.directory}</project.target>
                                 <users.file.location>${users.file.location}</users.file.location>
                                 <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
                             </systemPropertyVariables>
-                            <forkedProcessExitTimeoutInSeconds>5</forkedProcessExitTimeoutInSeconds>
+                            <forkedProcessExitTimeoutInSeconds>10</forkedProcessExitTimeoutInSeconds>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
fixes #534 

## Motivation

The build runs out of disk space which prevents adding new integration tests

## Modifications:

* Free up some disk space by:
  * following the workaround described [in this ticket](https://github.com/actions/runner-images/issues/2840#issuecomment-790492173)
  * removing pre-pulled docker images
* Add a new System property `camel.karaf.itest.keep.docker.images` to indicate whether the docker images should be removed after the test. Locally, you can leverage the Maven property `keep.docker.images.on.exit` to keep them or not. By default, the docker images are cleaned up to prevent the disk space leak
* Extend the forked process exit timeout to ensure that pax-exam can stop properly

## Result

Without these changes, we had `21G` available for the build and `0G` available after.
With these changes, we have `35G` available for the build and `23G` available after.
