### PR TITLE
Ref #501: Fix slip packages issues in debezium wrappers

### DIFF
--- a/components/camel-debezium/camel-debezium-db2/pom.xml
+++ b/components/camel-debezium/camel-debezium-db2/pom.xml
@@ -53,6 +53,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Must be removed once the split package issue is fixed in Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,6 +81,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!-- Must be removed once the split package issue is fixed in Camel -->
+                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-db2</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -53,6 +53,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Must be removed once the split package issue is fixed in Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,6 +81,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!-- Must be removed once the split package issue is fixed in Camel -->
+                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-oracle</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-sqlserver/pom.xml
+++ b/components/camel-debezium/camel-debezium-sqlserver/pom.xml
@@ -53,6 +53,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Must be removed once the split package issue is fixed in Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-debezium-common</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,6 +81,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!-- Must be removed once the split package issue is fixed in Camel -->
+                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-sqlserver</include>
                                 </includes>
                             </artifactSet>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -939,6 +939,7 @@
     <feature name='camel-debezium-db2' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-db2/${debezium-version}</bundle>
+        <bundle>wrap:mvn:io.debezium/debezium-storage-kafka/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-db2/${project.version}</bundle>
     </feature>
     <feature name='camel-debezium-mongodb' version='${project.version}' start-level='50'>
@@ -964,6 +965,14 @@
     <feature name='camel-debezium-oracle' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-oracle/${debezium-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.debezium/debezium-ddl-parser/${auto-detect-version}</bundle>
+        <!-- Use the wrap protocol to make org.antlr.v4.gui optional-->
+        <bundle>wrap:mvn:org.antlr/antlr4-runtime/${auto-detect-version}$overwrite=merge&amp;Import-Package=org.antlr.v4.gui*;resolution:=optional,*</bundle>
+        <bundle>wrap:mvn:io.debezium/debezium-storage-kafka/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.oracle.database.nls/orai18n/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.oracle.database.jdbc/ojdbc8/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-oracle/${project.version}</bundle>
     </feature>
     <feature name='camel-debezium-postgres' version='${project.version}' start-level='50'>
@@ -976,6 +985,8 @@
     <feature name='camel-debezium-sqlserver' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-sqlserver/${debezium-version}</bundle>
+        <bundle>wrap:mvn:io.debezium/debezium-storage-kafka/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:com.microsoft.sqlserver/mssql-jdbc/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-sqlserver/${project.version}</bundle>
     </feature>
     <feature name='camel-debug' version='${project.version}' start-level='50'>


### PR DESCRIPTION
fixes #501

## Motivation

Debezium features don't work due to a split packages issue in Camel

## Modifications:

* Add missing dependencies to the feature `camel-debezium-db2`, `camel-debezium-oracle`, and `camel-debezium-sqlserver`
* Add a workaround for the split packages issue in Camel