### PR TITLE
Ref #542: Restore camel-vm old behavior

### DIFF
--- a/components/camel-directvm/src/generated/resources/META-INF/org/apache/camel/karaf/component/directvm/direct-vm.json
+++ b/components/camel-directvm/src/generated/resources/META-INF/org/apache/camel/karaf/component/directvm/direct-vm.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-directvm",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.1-SNAPSHOT",
     "scheme": "direct-vm",
     "extendsScheme": "",
     "syntax": "direct-vm:name",

--- a/components/camel-vm/src/generated/resources/META-INF/org/apache/camel/karaf/component/vm/vm.json
+++ b/components/camel-vm/src/generated/resources/META-INF/org/apache/camel/karaf/component/vm/vm.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-vm",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.1-SNAPSHOT",
     "scheme": "vm",
     "extendsScheme": "",
     "syntax": "vm:name",

--- a/components/camel-vm/src/main/java/org/apache/camel/karaf/component/vm/VmConsumer.java
+++ b/components/camel-vm/src/main/java/org/apache/camel/karaf/component/vm/VmConsumer.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.karaf.component.vm;
 
-import org.apache.camel.*;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangeExtension;
+import org.apache.camel.Processor;
 import org.apache.camel.component.seda.SedaConsumer;
-import org.apache.camel.support.DefaultExchange;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.camel.support.ExchangeHelper;
 
 public class VmConsumer extends SedaConsumer implements CamelContextAware {
 
@@ -43,4 +42,23 @@ public class VmConsumer extends SedaConsumer implements CamelContextAware {
         this.camelContext = camelContext;
     }
 
+    @Override
+    protected Exchange prepareExchange(Exchange exchange) {
+        Exchange result = ExchangeHelper.copyExchangeWithProperties(exchange, camelContext);
+        ExchangeExtension exchangeExtension = result.getExchangeExtension();
+        exchangeExtension.setFromEndpoint(getEndpoint());
+        exchangeExtension.setFromRouteId(getRouteId());
+        return result;
+    }
+
+    @Override
+    protected void onProcessingDone(Exchange original, Exchange prepared) {
+        // copy result back
+        ExchangeHelper.copyResults(original, prepared);
+        // log exception if an exception occurred and was not handled
+        if (original.getException() != null) {
+            getExceptionHandler().handleException("Error processing exchange", original,
+                    original.getException());
+        }
+    }
 }


### PR DESCRIPTION
fixes #542 

## Motivation

After the deletion of camel-vm in favor of camel-seda, it has been decided to put it back in the camel-karaf project. Unfortunately, it was no longer possible to restore its old behavior entirely due to https://issues.apache.org/jira/browse/CAMEL-21343 which has been fixed in Camel 4.8.1, so it is possible to restore its behavior

## Modifications:

* Implement the methods needed to mimic the old behavior of camel-vm
* Add missing files after the upgrade to Camel 4.8.1