### PR TITLE
Ref #553: fix usage of routeBuilder in blueprint

### DIFF
--- a/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintContainerBeanRepository.java
+++ b/components/camel-blueprint/src/main/java/org/apache/camel/blueprint/BlueprintContainerBeanRepository.java
@@ -61,13 +61,13 @@ public class BlueprintContainerBeanRepository implements BeanRepository {
         }
 
         // just to be safe
-        if (answer == null) {
+        if (!type.isInstance(answer)) {
             return null;
         }
 
         try {
             return type.cast(answer);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             String msg = "Found bean: " + name + " in BlueprintContainer: " + blueprintContainer
                     + " of type: " + answer.getClass().getName() + " expected type was: " + type;
             throw new NoSuchBeanException(name, msg, e);


### PR DESCRIPTION
fixes #553 
**Cause :** 
The name "route" is looked up in the `DefaultVariableRepositoryFactory`, so if there is an object named "route" with a different type, it fails.

**Solution :** 
Exception should not be thrown when an object with matching name but different type is found, just return null in this case since the `DefaultRegistry` does not handle the `NoSuchBeanException`