### PR TITLE
Ref #547: Remove common from Debezium sub-components

### DIFF
--- a/components/camel-debezium/camel-debezium-db2/pom.xml
+++ b/components/camel-debezium/camel-debezium-db2/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-db2</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-mongodb/pom.xml
+++ b/components/camel-debezium/camel-debezium-mongodb/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-mongodb</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-mysql</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-oracle</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-postgres/pom.xml
+++ b/components/camel-debezium/camel-debezium-postgres/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-postgres</include>
                                 </includes>
                             </artifactSet>

--- a/components/camel-debezium/camel-debezium-sqlserver/pom.xml
+++ b/components/camel-debezium/camel-debezium-sqlserver/pom.xml
@@ -53,18 +53,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Must be removed once the split package issue is fixed in Camel -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debezium-common</artifactId>
-            <version>${camel-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -81,8 +69,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!-- Must be removed once the split package issue is fixed in Camel -->
-                                    <include>org.apache.camel:camel-debezium-common</include>
                                     <include>org.apache.camel:camel-debezium-sqlserver</include>
                                 </includes>
                             </artifactSet>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -951,8 +951,7 @@
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-embedded/${debezium-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-core/${debezium-version}$DynamicImport-Package=io.debezium.connector.*&amp;${spi-consumer}</bundle>
         <bundle>wrap:mvn:io.debezium/debezium-storage-file/${debezium-version}</bundle>
-        <!-- Uncomment when the split package issue is fixed in Camel -->
-        <!--<bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>-->
+        <bundle>mvn:org.apache.camel.karaf/camel-debezium-common/${project.version}</bundle>
     </feature>
     <feature name='camel-debezium-db2' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>


### PR DESCRIPTION
fixes #547 

## Motivation

We have a split package issue fixed in Camel so that we can remove the workaround.

## Modifications:

* Remove `camel-debezium-common` from all the wrappers
* Re-add `camel-debezium-common` to the feature of the same name