### PR TITLE
Ref #568: Add an integration test for AWS Kinesis

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -532,6 +532,9 @@
         <bundle dependency='true'>wrap:mvn:software.amazon.kinesis/amazon-kinesis-client/${amazon-kinesis-client-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/dynamodb/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudwatch/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-cbor-protocol/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/third-party-jackson-dataformat-cbor/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-kinesis/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-kms' version='${project.version}' start-level='50'>

--- a/tests/features/camel-aws2-kinesis/pom.xml
+++ b/tests/features/camel-aws2-kinesis/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-aws2-kinesis-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: AWS2 Kinesis</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws2-kinesis</artifactId>
+            <version>${camel-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/features/camel-aws2-kinesis/src/main/java/org/apache/karaf/camel/test/CamelAws2KinesisRouteSupplier.java
+++ b/tests/features/camel-aws2-kinesis/src/main/java/org/apache/karaf/camel/test/CamelAws2KinesisRouteSupplier.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import java.util.function.Function;
+
+import org.apache.camel.component.aws2.kinesis.Kinesis2Component;
+import org.apache.camel.component.aws2.kinesis.Kinesis2Configuration;
+import org.apache.camel.component.aws2.kinesis.Kinesis2Constants;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import static org.apache.camel.builder.Builder.constant;
+
+@Component(name = "karaf-camel-aws2-kinesis-test", immediate = true, service = CamelRouteSupplier.class)
+public class CamelAws2KinesisRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    private static final String HOST = System.getProperty("localstack.kinesis.host");
+    private static final String PORT = System.getProperty("localstack.kinesis.port");
+    private static final String REGION = System.getProperty("localstack.kinesis.region");
+    private static final String ACCESS_KEY = System.getProperty("localstack.kinesis.accessKey");
+    private static final String SECRET_KEY = System.getProperty("localstack.kinesis.secretKey");
+    private static final String STREAM_NAME = System.getProperty("localstack.kinesis.streamName");
+    private static final String COMPONENT_NAME = "aws2-kinesis";
+
+    @Override
+    public void configure(CamelContext camelContext) {
+        final Kinesis2Component kinesis2Component = new Kinesis2Component();
+        final Kinesis2Configuration configuration = new Kinesis2Configuration();
+        configuration.setAccessKey(ACCESS_KEY);
+        configuration.setSecretKey(SECRET_KEY);
+        configuration.setRegion(REGION);
+        configuration.setOverrideEndpoint(true);
+        configuration.setUriEndpointOverride(String.format("http://%s:%s", HOST, PORT));
+        kinesis2Component.setConfiguration(configuration);
+        camelContext.addComponent(COMPONENT_NAME, kinesis2Component);
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        configureConsumer(producerRoute
+                .setBody(constant("Hello Kinesis"))
+                .setHeader(Kinesis2Constants.PARTITION_KEY, constant("partition-1"))
+                .toF("%s://%s", COMPONENT_NAME, STREAM_NAME));
+    }
+
+    @Override
+    protected Function<RouteBuilder, RouteDefinition> consumerRoute() {
+        return builder ->
+                builder.fromF("%s://%s", COMPONENT_NAME, STREAM_NAME)
+                        .log("Received successfully: ${body}")
+                        .setBody(constant("OK"));
+    }
+}

--- a/tests/features/camel-aws2-kinesis/src/test/java/org/apache/karaf/camel/itest/CamelAws2KinesisITest.java
+++ b/tests/features/camel-aws2-kinesis/src/test/java/org/apache/karaf/camel/itest/CamelAws2KinesisITest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.apache.karaf.camel.itests.CamelKarafTestHint;
+import org.apache.karaf.camel.itests.GenericContainerResource;
+import org.apache.karaf.camel.itests.PaxExamWithExternalResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@CamelKarafTestHint(externalResourceProvider = CamelAws2KinesisITest.ExternalResourceProviders.class)
+@RunWith(PaxExamWithExternalResource.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelAws2KinesisITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("Hello Kinesis");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    public static final class ExternalResourceProviders {
+
+        private static final int LOCALSTACK_ORIGINAL_PORT = 4566;
+        private static final String STREAM_NAME = "my-stream";
+        private static final String ACCESS_KEY = "test";
+        private static final String SECRET_KEY = "test";
+        private static final String REGION = "us-east-1";
+        public static GenericContainerResource<LocalStackContainer> createAws2KinesisContainer() {
+
+            final LocalStackContainer localStackContainer =
+                    new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4.0"))
+                            .withServices(LocalStackContainer.Service.KINESIS);
+
+            return new GenericContainerResource<>(localStackContainer, resource -> {
+                try {
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_access_key_id", ACCESS_KEY, "--profile",
+                            "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "aws_secret_access_key", SECRET_KEY,
+                            "--profile", "localstack");
+                    localStackContainer.execInContainer("aws", "configure", "set", "region", REGION, "--profile", "localstack");
+                    localStackContainer.execInContainer("aws",
+                            "--endpoint-url=http://" + localStackContainer.getHost() + ":" + LOCALSTACK_ORIGINAL_PORT, "kinesis",
+                            "create-stream", "--stream-name", STREAM_NAME, "--shard-count", "1", "--region", REGION,
+                            "--profile", "localstack");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                resource.setProperty("localstack.kinesis.host", localStackContainer.getHost());
+                resource.setProperty("localstack.kinesis.port",
+                        Integer.toString(localStackContainer.getMappedPort(LOCALSTACK_ORIGINAL_PORT)));
+                resource.setProperty("localstack.kinesis.accessKey", ACCESS_KEY);
+                resource.setProperty("localstack.kinesis.secretKey", SECRET_KEY);
+                resource.setProperty("localstack.kinesis.region", REGION);
+                resource.setProperty("localstack.kinesis.streamName", STREAM_NAME);
+            });
+        }
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -49,6 +49,7 @@
         <module>camel-atom</module>
         <module>camel-avro</module>
         <module>camel-aws2-iam</module>
+        <module>camel-aws2-kinesis</module>
         <module>camel-aws2-s3</module>
         <module>camel-aws2-ses</module>
         <module>camel-aws2-sns</module>


### PR DESCRIPTION
fixes #568 for 4.9

## Motivation

AWS Kinesis feature doesn't seem to work so we need an integration test to ensure that it works as expected

## Modifications:

* Add missing dependencies to the feature `camel-aws2-kinesis`
* Add an integration test