### PR TITLE
Ref #571: Add an integration test for Groovy - 4.9

### DIFF
--- a/tests/features/camel-groovy/pom.xml
+++ b/tests/features/camel-groovy/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-groovy-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Groovy</name>
+
+</project>

--- a/tests/features/camel-groovy/src/main/java/org/apache/karaf/camel/test/CamelGroovyRouteSupplier.java
+++ b/tests/features/camel-groovy/src/main/java/org/apache/karaf/camel/test/CamelGroovyRouteSupplier.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+import static org.apache.camel.builder.Builder.constant;
+
+
+@Component(
+        name = "karaf-camel-groovy-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelGroovyRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        producerRoute
+                .log("received message ${body}")
+                .setBody().groovy("groovy.lang.Tuple.tuple(body)")
+                .log("message modified ${body}")
+                .choice()
+                .when().groovy("body instanceof groovy.lang.Tuple && body.size() == 1")
+                    .setBody(constant("OK"))
+                .otherwise()
+                    .setBody(constant("KO"))
+                .end()
+                .log("sending message ${body}")
+                .toF("mock:%s", getResultMockName());
+    }
+}
+

--- a/tests/features/camel-groovy/src/test/java/org/apache/karaf/camel/itest/CamelGroovyITest.java
+++ b/tests/features/camel-groovy/src/test/java/org/apache/karaf/camel/itest/CamelGroovyITest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelGroovyITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedBodiesReceived("OK");
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    public String getBodyToSend() {
+        return "Hello Groovy";
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -85,6 +85,7 @@
         <module>camel-flatpack</module>
         <module>camel-ftp</module>
         <module>camel-google-pubsub</module>
+        <module>camel-groovy</module>
         <module>camel-gson</module>
         <module>camel-hazelcast</module>
         <module>camel-http</module>


### PR DESCRIPTION
fixes #571 for 4.9

## Motivation

There is no integration test for Groovy, we need one to ensure that it works as expected

## Modifications:

* Add an integration test