### PR TITLE
Ref #579: camel-vm - Handover completions

### DIFF
--- a/components/camel-vm/pom.xml
+++ b/components/camel-vm/pom.xml
@@ -47,6 +47,25 @@
             <artifactId>camel-seda</artifactId>
             <version>${camel-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <version>${camel-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- logging for testing -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-vm/src/main/java/org/apache/camel/karaf/component/vm/VmConsumer.java
+++ b/components/camel-vm/src/main/java/org/apache/camel/karaf/component/vm/VmConsumer.java
@@ -45,6 +45,7 @@ public class VmConsumer extends SedaConsumer implements CamelContextAware {
     @Override
     protected Exchange prepareExchange(Exchange exchange) {
         Exchange result = ExchangeHelper.copyExchangeWithProperties(exchange, camelContext);
+        exchange.getExchangeExtension().handoverCompletions(result);
         ExchangeExtension exchangeExtension = result.getExchangeExtension();
         exchangeExtension.setFromEndpoint(getEndpoint());
         exchangeExtension.setFromRouteId(getRouteId());

--- a/components/camel-vm/src/test/java/org/apache/camel/karaf/component/vm/VmComplexInOutTest.java
+++ b/components/camel-vm/src/test/java/org/apache/camel/karaf/component/vm/VmComplexInOutTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.karaf.component.vm;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VmComplexInOutTest extends CamelTestSupport {
+
+    @Test
+    void testInOut() throws Exception {
+        getMockEndpoint("mock:result-inner").expectedBodiesReceived("Bye World");
+        getMockEndpoint("mock:result").expectedBodiesReceived("OK");
+
+        String out = template.requestBody("direct:start", "Hello World", String.class);
+        assertEquals("OK", out);
+
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                getContext().setTracing(true);
+
+                from("direct:start").to("vm:a").setBody(constant("OK")).to("mock:result");
+
+                from("vm:a").to("log:bar", "vm:b");
+                from("vm:b").delay(10).to("direct:c");
+
+                from("direct:c").transform(constant("Bye World")).to("mock:result-inner");
+            }
+        };
+    }
+}

--- a/components/camel-vm/src/test/resources/log4j2.properties
+++ b/components/camel-vm/src/test/resources/log4j2.properties
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+appender.file.type = File
+appender.file.name = file
+appender.file.fileName = target/camel-vm-test.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+appender.out.type = Console
+appender.out.name = out
+appender.out.layout.type = PatternLayout
+appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+rootLogger.level = INFO
+rootLogger.appenderRef.file.ref = file


### PR DESCRIPTION
fixes #579 

## Motivation

In case the producer of camel-vm is used in a middle of a route, the rest of the camel route is never called

## Modifications:

* Handover completions on prepare exchange