### PR TITLE
Ref #581: camel-debezium-mysql - Use the tag corresponding to debezium

### DIFF
--- a/tests/features/camel-debezium-mysql/pom.xml
+++ b/tests/features/camel-debezium-mysql/pom.xml
@@ -51,4 +51,40 @@
             <version>${camel-version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*Test.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <debezium.version>${debezium-version}</debezium.version>
+                                <camel.karaf.itest.dump.logs>${dump.logs.on.failure}</camel.karaf.itest.dump.logs>
+                                <camel.karaf.itest.keep.docker.images>${keep.docker.images.on.exit}</camel.karaf.itest.keep.docker.images>
+                                <camel.karaf.version>${project.version}</camel.karaf.version>
+                                <project.version>${project.version}</project.version>
+                                <project.target>${project.build.directory}</project.target>
+                                <users.file.location>${users.file.location}</users.file.location>
+                                <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
+                            </systemPropertyVariables>
+                            <forkedProcessExitTimeoutInSeconds>10</forkedProcessExitTimeoutInSeconds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tests/features/camel-debezium-mysql/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumMysqlITest.java
+++ b/tests/features/camel-debezium-mysql/src/test/java/org/apache/karaf/camel/itest/CamelDebeziumMysqlITest.java
@@ -45,7 +45,6 @@ public class CamelDebeziumMysqlITest extends AbstractCamelSingleFeatureResultMoc
 
     public static final class ExternalResourceProviders {
 
-        private static final String DEBEZIUM_VERSION = "2.7";
         private static final String MYSQL_IMAGE = "quay.io/debezium/example-mysql";
         private static final String SOURCE_DB_NAME = "inventory";
         private static final String SOURCE_DB_TABLE = String.format("%s.products", SOURCE_DB_NAME);
@@ -54,7 +53,7 @@ public class CamelDebeziumMysqlITest extends AbstractCamelSingleFeatureResultMoc
 
         public static GenericContainerResource<MYSQLContainer> createMySQLContainer() {
 
-            MYSQLContainer container = new MYSQLContainer(DockerImageName.parse(MYSQL_IMAGE).withTag(DEBEZIUM_VERSION)
+            MYSQLContainer container = new MYSQLContainer(DockerImageName.parse(MYSQL_IMAGE).withTag(System.getProperty("debezium.version"))
                     .asCompatibleSubstituteFor("mysql"))
                     .withUsername(SOURCE_DB_USERNAME)
                     .withPassword(SOURCE_DB_PASSWORD);


### PR DESCRIPTION
fixes #581 

## Motivation

The integration test of camel-debezium-mysql fails due to an access denied

## Modifications

* Align the version of the docker image with the version of debezium used for the test to prevent behavior changes