### PR TITLE
Ref #590 Add Bundle-Name and Bundle-SymbolicName to wrapped bundles

### DIFF
--- a/features/pom.xml
+++ b/features/pom.xml
@@ -76,6 +76,7 @@
                         <goals>
                             <goal>auto-detect-version</goal>
                             <goal>ensure-wrap-bundle-version</goal>
+                            <goal>ensure-wrap-bundle-name</goal>
                             <goal>configure-wrap-spi-provider</goal>
                         </goals>
                         <configuration>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -859,7 +859,7 @@
         the fragmented host option will enforce both bundles to share the same class loader,
         'okhttp' was chosen as the host because 'okhttp-urlconnection' contains only one package with 2 classes -->
         <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp/${squareup-okhttp-version}$Bundle-SymbolicName=com.squareup.okhttp3.okhttp</bundle>
-        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp-urlconnection/${squareup-okhttp-version}$Fragment-Host=wrap_com.squareup.okhttp3.okhttp;bundle-version=${squareup-okhttp-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp-urlconnection/${squareup-okhttp-version}$Fragment-Host=com.squareup.okhttp3.okhttp;bundle-version=${squareup-okhttp-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-couchdb/${project.version}</bundle>
     </feature>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -859,7 +859,7 @@
         the fragmented host option will enforce both bundles to share the same class loader,
         'okhttp' was chosen as the host because 'okhttp-urlconnection' contains only one package with 2 classes -->
         <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp/${squareup-okhttp-version}$Bundle-SymbolicName=com.squareup.okhttp3.okhttp</bundle>
-        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp-urlconnection/${squareup-okhttp-version}$Fragment-Host=com.squareup.okhttp3.okhttp;bundle-version=${squareup-okhttp-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp-urlconnection/${squareup-okhttp-version}$Fragment-Host=wrap_com.squareup.okhttp3.okhttp;bundle-version=${squareup-okhttp-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-couchdb/${project.version}</bundle>
     </feature>
@@ -1128,7 +1128,7 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:com.alibaba/fastjson/${fastjson-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.alibaba.fastjson2/fastjson2/${auto-detect-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:com.alibaba.fastjson2/fastjson2-extension/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.alibaba.fastjson2/fastjson2-extension/${auto-detect-version}$Fragment-Host=wrap_com.alibaba.fastjson2.fastjson2</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-fastjson/${project.version}</bundle>
     </feature>
     <feature name='camel-fhir' version='${project.version}' start-level='50'>

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
@@ -43,7 +43,7 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
     private static final String BUNDLE_NAME = "Bundle-Name";
     private static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
 
-    static String toPascalCase(String kebabCase) {
+    private static String toPascalCase(String kebabCase) {
         // Handle null or empty string
         if (kebabCase == null || kebabCase.isEmpty()) {
             return kebabCase;
@@ -86,7 +86,7 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
     String processLocation(WrappedBundle wrappedBundle) throws Exception {
         String location = wrappedBundle.getBundle().getLocation();
         String instructions = wrappedBundle.getInstructions();
-        boolean dollarNeeded = !(instructions != null && instructions.contains("$"));
+        boolean dollarNeeded = instructions == null || !instructions.contains("$");
 
         String bundleNameHeader = "%s=Wrap%%20of%%20%s".formatted(BUNDLE_NAME, toPascalCase(wrappedBundle.getArtifactId()));
         String bundleSymbolicNameHeader = "%s=wrap_%s.%s".formatted(BUNDLE_SYMBOLIC_NAME, wrappedBundle.getGroupId(), wrappedBundle.getArtifactId());
@@ -115,14 +115,12 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
                         // "amp;" is automatically added
                         dollarNeeded = false;
                         location = sb.insert(versionHeaderStartIndex, "$%s&".formatted(entry.getValue())).toString();
-                        hasChanged = true;
-                        break;
                     } else {
                         // "amp;" is automatically added
                         location = sb.insert(versionHeaderStartIndex, "%s&".formatted(entry.getValue())).toString();
-                        hasChanged = true;
-                        break;
                     }
+                    hasChanged = true;
+                    break;
                 }
             }
             if (hasChanged) {

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
@@ -39,8 +39,8 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
             "Require-Bundle",
             "Require-Capability");
     
-    static final String BUNDLE_NAME = "Bundle-Name";
-    static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
+    private static final String BUNDLE_NAME = "Bundle-Name";
+    private static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
 
     static String toPascalCase(String kebabCase) {
         // Handle null or empty string
@@ -55,18 +55,18 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
         // Capitalize first letter of each word
         for (int i = 0; i < words.length; i++) {
             String word = words[i];
-            if (!word.isEmpty()) {
-                result.append(Character.toUpperCase(word.charAt(0)));
-                if (word.length() > 1) {
-                    result.append(word.substring(1).toLowerCase());
-                }
-                // Only add %20 if it's not the last word
-                if (i < words.length - 1) {
-                    result.append("%20");
-                }
+            if (word.isEmpty()) {
+                continue;
+            }
+            result.append(Character.toUpperCase(word.charAt(0)));
+            if (word.length() > 1) {
+                result.append(word.substring(1).toLowerCase());
+            }
+            // Only add %20 if it's not the last word
+            if (i < words.length - 1) {
+                result.append("%20");
             }
         }
-
         return result.toString();
     }
 
@@ -105,13 +105,13 @@ public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
             // add Bundle-Version before
             if (location.contains(header)) {
                 int versionHeaderStartIndex = location.indexOf(header);
-                if (!dollarNeeded.get()) {
-                    // "amp;" is automatically added
-                    return sb.insert(versionHeaderStartIndex, "%s&".formatted(fullHeader)).toString();
-                } else {
+                if (dollarNeeded.get()) {
                     // "amp;" is automatically added
                     dollarNeeded.set(false);
                     return sb.insert(versionHeaderStartIndex, "$%s&".formatted(fullHeader)).toString();
+                } else {
+                    // "amp;" is automatically added
+                    return sb.insert(versionHeaderStartIndex, "%s&".formatted(fullHeader)).toString();
                 }
             }
         }

--- a/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/main/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojo.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.karaf.feature.maven;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.karaf.features.internal.model.Bundle;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+@Mojo(name = "ensure-wrap-bundle-name", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class EnsureWrapBundleNameMojo extends AbstractWrapBundleMojo {
+
+    private static final List<String> HEADERS_AFTER_BUNDLE_NAME = Arrays.asList(
+            "Bundle-Version",
+            "DynamicImport-Package",
+            "Export-Package",
+            "Export-Service",
+            "Fragment-Host",
+            "Import-Package",
+            "Import-Service",
+            "Provide-Capability",
+            "Require-Bundle",
+            "Require-Capability");
+    
+    static final String BUNDLE_NAME = "Bundle-Name";
+    static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
+
+    static String toPascalCase(String kebabCase) {
+        // Handle null or empty string
+        if (kebabCase == null || kebabCase.isEmpty()) {
+            return kebabCase;
+        }
+
+        // Split by hyphen
+        String[] words = kebabCase.split("-");
+        StringBuilder result = new StringBuilder();
+
+        // Capitalize first letter of each word
+        for (int i = 0; i < words.length; i++) {
+            String word = words[i];
+            if (!word.isEmpty()) {
+                result.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    result.append(word.substring(1).toLowerCase());
+                }
+                // Only add %20 if it's not the last word
+                if (i < words.length - 1) {
+                    result.append("%20");
+                }
+            }
+        }
+
+        return result.toString();
+    }
+
+    @Override
+    protected boolean processWrappedBundle(WrappedBundle wrappedBundle) {
+        Bundle bundle = wrappedBundle.getBundle();
+        String location = bundle.getLocation();
+        try {
+            bundle.setLocation(processLocation(wrappedBundle));
+        } catch (Exception e) {
+            getLog().error("Could not process the Bundle location '%s': %s".formatted(location, e.getMessage()), e);
+        }
+        return false;
+    }
+
+    String processLocation(WrappedBundle wrappedBundle) throws Exception {
+        String location = wrappedBundle.getBundle().getLocation();
+        String instructions = wrappedBundle.getInstructions();
+        AtomicBoolean dollarNeeded = new AtomicBoolean(!(instructions!=null && instructions.contains("$")));
+
+        String bundleNameHeader = "%s=Wrap%%20of%%20%s".formatted(BUNDLE_NAME, toPascalCase(wrappedBundle.getArtifactId()));
+        String bundleSymbolicNameHeader = "%s=wrap_%s.%s".formatted(BUNDLE_SYMBOLIC_NAME, wrappedBundle.getGroupId(), wrappedBundle.getArtifactId());
+
+        location = insertHeaderIfNeeded(dollarNeeded, location, BUNDLE_NAME, bundleNameHeader);
+        return insertHeaderIfNeeded(dollarNeeded, location, BUNDLE_SYMBOLIC_NAME, bundleSymbolicNameHeader);
+    }
+
+    private String insertHeaderIfNeeded(AtomicBoolean dollarNeeded, String location, String headerName, String fullHeader) {
+        if (location.contains(headerName)) {
+            return location;
+        }
+        StringBuilder sb = new StringBuilder(location);
+
+        // insert before existing headers header
+        for (String header : HEADERS_AFTER_BUNDLE_NAME) {
+            // add Bundle-Version before
+            if (location.contains(header)) {
+                int versionHeaderStartIndex = location.indexOf(header);
+                if (!dollarNeeded.get()) {
+                    // "amp;" is automatically added
+                    return sb.insert(versionHeaderStartIndex, "%s&".formatted(fullHeader)).toString();
+                } else {
+                    // "amp;" is automatically added
+                    dollarNeeded.set(false);
+                    return sb.insert(versionHeaderStartIndex, "$%s&".formatted(fullHeader)).toString();
+                }
+            }
+        }
+
+        // insert at the end
+        if (dollarNeeded.get()) {
+            dollarNeeded.set(false);
+            return sb.insert(location.length(), "$%s".formatted(fullHeader)).toString();
+        } else {
+            // "amp;" is automatically added
+            return sb.insert(location.length(), "&%s".formatted(fullHeader)).toString();
+        }
+    }
+}

--- a/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojoTest.java
+++ b/tooling/camel-karaf-feature-maven-plugin/src/test/java/org/apache/camel/karaf/feature/maven/EnsureWrapBundleNameMojoTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.karaf.feature.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.karaf.features.internal.model.Bundle;
+import org.junit.jupiter.api.Test;
+
+public class EnsureWrapBundleNameMojoTest {
+
+    private final EnsureWrapBundleNameMojo ensureNameMojo = new EnsureWrapBundleNameMojo();
+
+    @Test
+    void modifyLocationTest() throws Exception {
+        Bundle bundle = new Bundle();
+        // add bundle name at the end as first wrap protocol option
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0");
+        String expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-Name=Wrap%20of%20Odata%20Server%20Core&Bundle-SymbolicName=wrap_org.apache.olingo.odata-server-core";
+        WrappedBundle wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+        // add bundle name at the end but not as first wrap protocol option
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge");
+        expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Name=Wrap%20of%20Odata%20Server%20Core&Bundle-SymbolicName=wrap_org.apache.olingo.odata-server-core";
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+        // add bundle name before existing wrap protocol header that should be declared after
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Export-Package=org.apache.olingo.*;version=5.0.0");
+        expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Name=Wrap%20of%20Odata%20Server%20Core&Bundle-SymbolicName=wrap_org.apache.olingo.odata-server-core&Export-Package=org.apache.olingo.*;version=5.0.0";
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+        // add bundle name before existing wrap protocol header that should be declared after
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Version=5.0.0&Export-Package=org.apache.olingo.*;version=5.0.0");
+        expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$overwrite=merge&Bundle-Name=Wrap%20of%20Odata%20Server%20Core&Bundle-SymbolicName=wrap_org.apache.olingo.odata-server-core&Bundle-Version=5.0.0&Export-Package=org.apache.olingo.*;version=5.0.0";
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+        // don't override the Bundle-Name if present
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-Name=MyName");
+        expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-Name=MyName&Bundle-SymbolicName=wrap_org.apache.olingo.odata-server-core";
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+        // don't override the Bundle-SymbolicName if present
+        bundle.setLocation("wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-SymbolicName=MyName");
+        expected = "wrap:mvn:org.apache.olingo/odata-server-core/5.0.0$Bundle-SymbolicName=MyName&Bundle-Name=Wrap%20of%20Odata%20Server%20Core";
+        wrappedBundle = WrappedBundle.fromBundle(bundle);
+        assertNotNull(wrappedBundle);
+        assertEquals(expected, ensureNameMojo.processLocation(wrappedBundle));
+
+    }
+
+
+}


### PR DESCRIPTION
Fixes #590 

**Motivation**
Very long names in karaf console when listing bundles by names or symbolic names

**Modifications**:
Add Bundle-Name= and Bundle-SymbolicName= to the wrapped bundles