### PR TITLE
Add missing TW2 dependency to jakarta jaxb runtime

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -64,6 +64,7 @@
     </feature>
 
     <feature name="jaxb-runtime" version="${jaxb-core-version}">
+        <feature prerequisite="true">wrap</feature>
         <feature version="[4,5)">jakarta-xml-bind</feature>
         <bundle dependency="true">mvn:com.sun.istack/istack-commons-runtime/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-core/${glassfish-jaxb-runtime-version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -61,8 +61,6 @@
     <feature name="jaxb-runtime" version="${jaxb3-core-version}">
         <feature version="[3,4)">jakarta-xml-bind</feature>
         <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/${jaxb3-core-version}</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-impl/${jaxb3-impl-version}</bundle>
-        <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-osgi/${jaxb3-osgi-version}</bundle>
     </feature>
 
     <feature name="jaxb-runtime" version="${jaxb-core-version}">
@@ -70,7 +68,7 @@
         <bundle dependency="true">mvn:com.sun.istack/istack-commons-runtime/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-core/${glassfish-jaxb-runtime-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-runtime/${glassfish-jaxb-runtime-version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/${glassfish-jaxb-runtime-version}$Bundle-Name=JAXB TXW2&amp;Bundle-SymbolicName=org.glassfish.jaxb.tw2&amp;Bundle-Version=${glassfish-jaxb-runtime-version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/${glassfish-jaxb-runtime-version}$Bundle-Name=JAXB%20TXW2&amp;Bundle-SymbolicName=org.glassfish.jaxb.tw2&amp;Bundle-Version=${glassfish-jaxb-runtime-version}</bundle>
         <bundle>mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
     </feature>
 
@@ -2332,6 +2330,7 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[3,4)'>jakarta-validation</feature>
+        <feature version='[3,4)'>jaxb-runtime</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-tooling-util/${camel-version}$Export-Package=org.apache.camel*;version=${camel-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.camel/camel-xml-io/${camel-version}$Export-Package=org.apache.camel*;version=${camel-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2-version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -69,7 +69,8 @@
         <feature version="[4,5)">jakarta-xml-bind</feature>
         <bundle dependency="true">mvn:com.sun.istack/istack-commons-runtime/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-core/${glassfish-jaxb-runtime-version}</bundle>
-        <bundle dependency='true'>mvn:org.glassfish.jaxb/jaxb-runtime/${glassfish-jaxb-runtime-version}</bundle>
+        <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-runtime/${glassfish-jaxb-runtime-version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/${glassfish-jaxb-runtime-version}$Bundle-Name=JAXB TXW2&amp;Bundle-SymbolicName=org.glassfish.jaxb.tw2&amp;Bundle-Version=${glassfish-jaxb-runtime-version}</bundle>
         <bundle>mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
     </feature>
 

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -69,7 +69,7 @@
         <bundle dependency="true">mvn:com.sun.istack/istack-commons-runtime/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-core/${glassfish-jaxb-runtime-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.jaxb/jaxb-runtime/${glassfish-jaxb-runtime-version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/${glassfish-jaxb-runtime-version}$Bundle-Name=JAXB%20TXW2&amp;Bundle-SymbolicName=org.glassfish.jaxb.tw2&amp;Bundle-Version=${glassfish-jaxb-runtime-version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.jaxb/txw2/${glassfish-jaxb-runtime-version}</bundle>
         <bundle>mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
         <camel-osgi-jakarta-annotation-version>[3,4)</camel-osgi-jakarta-annotation-version>
         <camel-osgi-jakarta-activation-version>[2.1,3)</camel-osgi-jakarta-activation-version>
         <camel-osgi-jakarta-activation-runtime-version>[2,3)</camel-osgi-jakarta-activation-runtime-version>
-        <camel-osgi-jakarta-bind-version>[3,5)</camel-osgi-jakarta-bind-version>
+        <camel-osgi-jakarta-bind-version>[4,5)</camel-osgi-jakarta-bind-version>
         <camel-osgi-jakarta-jws-version>[3,4)</camel-osgi-jakarta-jws-version>
         <camel-osgi-jakarta-servlet-version>[5,7)</camel-osgi-jakarta-servlet-version>
         <camel-osgi-jakarta-soap-version>[3,4)</camel-osgi-jakarta-soap-version>


### PR DESCRIPTION
Fixes #619

Without this dependency karaf loads jaxb-runtime version 3 which in turn causes feature resolving to be extremely slow in some cases e.g. installing camel-cxf feature.