### PR TITLE
Added JOLT servicemix bundle dependency.

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1814,7 +1814,7 @@
     </feature>
     <feature name='camel-jolt' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:com.bazaarvoice.jolt/jolt-core/${jolt-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bazaarvoice-jolt/${jolt-bundle-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jolt/${project.version}</bundle>
     </feature>
     <feature name='camel-jooq' version='${project.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <libthrift-version>0.21.0</libthrift-version>
         <jodatime2-version>2.13.1</jodatime2-version>
         <jolokia-version>2.2.5</jolokia-version>
-        <jolt-version>0.1.8</jolt-version>
+        <jolt-bundle-version>0.1.8_1</jolt-bundle-version>
         <jool-version>0.9.15</jool-version>
         <jooq-version>3.19.22</jooq-version>
         <joor-version>0.9.15</joor-version>


### PR DESCRIPTION
JOLT servicemix bundle has exports which help other bundles to make use of JOLT classes in Karaf.