### PR TITLE
Added JOLT json-utils bundle in camel-jolt feature

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1814,7 +1814,8 @@
     </feature>
     <feature name='camel-jolt' version='${project.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:com.bazaarvoice.jolt/jolt-core/${jolt-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.bazaarvoice.jolt/json-utils/${jolt-version}$overwrite=merge&amp;Export-Package=com.bazaarvoice.jolt*;version=${jolt-version}&amp;Import-Package=*;resolution:=optional</bundle>
+        <bundle dependency='true'>wrap:mvn:com.bazaarvoice.jolt/jolt-core/${jolt-version}$overwrite=merge&amp;Export-Package=com.bazaarvoice.jolt*;version=${jolt-version}&amp;Import-Package=*;resolution:=optional</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jolt/${project.version}</bundle>
     </feature>
     <feature name='camel-jooq' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Took reference from servicemix jolt bundle which shades json-utils and jolt-core together.