### PR TITLE
Added SAAJ implementation feature for camel-cxf

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -54,6 +54,13 @@
         <bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/${jakarta-validation-api-version}</bundle>
     </feature>
 
+    <feature name="jakarta-soap-implementation" version="${jakarta-soap-implementation-version}">
+        <bundle dependency="true">wrap:mvn:org.jvnet.mimepull/mimepull/${jvnet-mimepull-version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.jvnet.staxex/stax-ex/${jvnet-staxex-version}</bundle>
+        <bundle dependency="true">wrap:mvn:com.sun.xml.fastinfoset/FastInfoset/${sun-fastinfoset-version}</bundle>
+        <bundle dependency="true">wrap:mvn:com.sun.xml.messaging.saaj/saaj-impl/${jakarta-soap-implementation-version}</bundle>
+    </feature>
+
     <feature name="jaxb-runtime" version="${jaxb3-core-version}">
         <feature version="[3,4)">jakarta-xml-bind</feature>
         <bundle dependency="true">mvn:com.sun.xml.bind/jaxb-core/${jaxb3-core-version}</bundle>
@@ -933,6 +940,7 @@
         <feature version="${camel-osgi-jakarta-annotation2-version}">jakarta-annotation</feature>
         <feature version="[6,7)">jakarta-servlet</feature>
         <feature version="[3,4)">jakarta-validation</feature>
+        <feature version="${camel-osgi-saaj-version}">jakarta-soap-implementation</feature>
         <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
         <bundle dependency="true">mvn:org.apache.neethi/neethi/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${auto-detect-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -575,6 +575,10 @@
         <jakarta-validation-api-version>3.0.2</jakarta-validation-api-version>
         <jakarta-ws-rs-api-version>3.1.0</jakarta-ws-rs-api-version>
         <jakarta-xml-bind3-api-version>3.0.1</jakarta-xml-bind3-api-version>
+        <jakarta-soap-implementation-version>3.0.4</jakarta-soap-implementation-version>
+        <jvnet-mimepull-version>1.10.0</jvnet-mimepull-version>
+        <jvnet-staxex-version>2.1.0</jvnet-staxex-version>
+        <sun-fastinfoset-version>2.1.1</sun-fastinfoset-version>
         <javax-servlet3-api-version>3.1.0</javax-servlet3-api-version>
         <jaxb3-core-version>3.0.2</jaxb3-core-version>
         <jaxb3-impl-version>3.0.2</jaxb3-impl-version>


### PR DESCRIPTION
Missing Jakarta soap implementation causes "Provider com.sun.xml.messaging.saaj.soap.SAAJMetaFactoryImpl not found" error for camel-cxf at runtime.