### PR TITLE
Upgrade to Camel 4.18.1

### DIFF
--- a/components/camel-activemq/pom.xml
+++ b/components/camel-activemq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-activemq6/pom.xml
+++ b/components/camel-activemq6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-chatscript/pom.xml
+++ b/components/camel-ai/camel-chatscript/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-djl/pom.xml
+++ b/components/camel-ai/camel-djl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-docling/pom.xml
+++ b/components/camel-ai/camel-docling/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-kserve/pom.xml
+++ b/components/camel-ai/camel-kserve/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-agent/pom.xml
+++ b/components/camel-ai/camel-langchain4j-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-chat/pom.xml
+++ b/components/camel-ai/camel-langchain4j-chat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-core/pom.xml
+++ b/components/camel-ai/camel-langchain4j-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-embeddings/pom.xml
+++ b/components/camel-ai/camel-langchain4j-embeddings/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-embeddingstore/pom.xml
+++ b/components/camel-ai/camel-langchain4j-embeddingstore/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-tokenizer/pom.xml
+++ b/components/camel-ai/camel-langchain4j-tokenizer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-tools/pom.xml
+++ b/components/camel-ai/camel-langchain4j-tools/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-web-search/pom.xml
+++ b/components/camel-ai/camel-langchain4j-web-search/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-milvus/pom.xml
+++ b/components/camel-ai/camel-milvus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-neo4j/pom.xml
+++ b/components/camel-ai/camel-neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-openai/pom.xml
+++ b/components/camel-ai/camel-openai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-pinecone/pom.xml
+++ b/components/camel-ai/camel-pinecone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-qdrant/pom.xml
+++ b/components/camel-ai/camel-qdrant/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-tensorflow-serving/pom.xml
+++ b/components/camel-ai/camel-tensorflow-serving/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-torchserve/pom.xml
+++ b/components/camel-ai/camel-torchserve/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-weaviate/pom.xml
+++ b/components/camel-ai/camel-weaviate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/pom.xml
+++ b/components/camel-ai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-amqp/pom.xml
+++ b/components/camel-amqp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-arangodb/pom.xml
+++ b/components/camel-arangodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-as2/pom.xml
+++ b/components/camel-as2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-asn1/pom.xml
+++ b/components/camel-asn1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-asterisk/pom.xml
+++ b/components/camel-asterisk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-atmosphere-websocket/pom.xml
+++ b/components/camel-atmosphere-websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-atom/pom.xml
+++ b/components/camel-atom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-attachments/pom.xml
+++ b/components/camel-attachments/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-avro-rpc-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-avro-rpc-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro/pom.xml
+++ b/components/camel-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-bedrock/pom.xml
+++ b/components/camel-aws/camel-aws-bedrock/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-cloudtrail/pom.xml
+++ b/components/camel-aws/camel-aws-cloudtrail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-common/pom.xml
+++ b/components/camel-aws/camel-aws-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-config/pom.xml
+++ b/components/camel-aws/camel-aws-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-parameter-store/pom.xml
+++ b/components/camel-aws/camel-aws-parameter-store/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-secrets-manager/pom.xml
+++ b/components/camel-aws/camel-aws-secrets-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-security-hub/pom.xml
+++ b/components/camel-aws/camel-aws-security-hub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-xray/pom.xml
+++ b/components/camel-aws/camel-aws-xray/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-comprehend/pom.xml
+++ b/components/camel-aws/camel-aws2-comprehend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-cw/pom.xml
+++ b/components/camel-aws/camel-aws2-cw/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ddb/pom.xml
+++ b/components/camel-aws/camel-aws2-ddb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ec2/pom.xml
+++ b/components/camel-aws/camel-aws2-ec2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ecs/pom.xml
+++ b/components/camel-aws/camel-aws2-ecs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-eks/pom.xml
+++ b/components/camel-aws/camel-aws2-eks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-eventbridge/pom.xml
+++ b/components/camel-aws/camel-aws2-eventbridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-iam/pom.xml
+++ b/components/camel-aws/camel-aws2-iam/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-kms/pom.xml
+++ b/components/camel-aws/camel-aws2-kms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-lambda/pom.xml
+++ b/components/camel-aws/camel-aws2-lambda/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-mq/pom.xml
+++ b/components/camel-aws/camel-aws2-mq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-msk/pom.xml
+++ b/components/camel-aws/camel-aws2-msk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-polly/pom.xml
+++ b/components/camel-aws/camel-aws2-polly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-redshift/pom.xml
+++ b/components/camel-aws/camel-aws2-redshift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-rekognition/pom.xml
+++ b/components/camel-aws/camel-aws2-rekognition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-s3-vectors/pom.xml
+++ b/components/camel-aws/camel-aws2-s3-vectors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-s3/pom.xml
+++ b/components/camel-aws/camel-aws2-s3/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sns/pom.xml
+++ b/components/camel-aws/camel-aws2-sns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sqs/pom.xml
+++ b/components/camel-aws/camel-aws2-sqs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-step-functions/pom.xml
+++ b/components/camel-aws/camel-aws2-step-functions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sts/pom.xml
+++ b/components/camel-aws/camel-aws2-sts/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-textract/pom.xml
+++ b/components/camel-aws/camel-aws2-textract/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-timestream/pom.xml
+++ b/components/camel-aws/camel-aws2-timestream/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-transcribe/pom.xml
+++ b/components/camel-aws/camel-aws2-transcribe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-translate/pom.xml
+++ b/components/camel-aws/camel-aws2-translate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-cosmosdb/pom.xml
+++ b/components/camel-azure/camel-azure-cosmosdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-eventgrid/pom.xml
+++ b/components/camel-azure/camel-azure-eventgrid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-eventhubs/pom.xml
+++ b/components/camel-azure/camel-azure-eventhubs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-files/pom.xml
+++ b/components/camel-azure/camel-azure-files/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-key-vault/pom.xml
+++ b/components/camel-azure/camel-azure-key-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-schema-registry/pom.xml
+++ b/components/camel-azure/camel-azure-schema-registry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-servicebus/pom.xml
+++ b/components/camel-azure/camel-azure-servicebus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-blob/pom.xml
+++ b/components/camel-azure/camel-azure-storage-blob/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-datalake/pom.xml
+++ b/components/camel-azure/camel-azure-storage-datalake/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-queue/pom.xml
+++ b/components/camel-azure/camel-azure-storage-queue/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/pom.xml
+++ b/components/camel-azure/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-barcode/pom.xml
+++ b/components/camel-barcode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-base64/pom.xml
+++ b/components/camel-base64/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bean-validator/pom.xml
+++ b/components/camel-bean-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-beanio/pom.xml
+++ b/components/camel-beanio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bindy/pom.xml
+++ b/components/camel-bindy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-blueprint/pom.xml
+++ b/components/camel-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bonita/pom.xml
+++ b/components/camel-bonita/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-box/pom.xml
+++ b/components/camel-box/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-browse/pom.xml
+++ b/components/camel-browse/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-caffeine/pom.xml
+++ b/components/camel-caffeine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cbor/pom.xml
+++ b/components/camel-cbor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-chunk/pom.xml
+++ b/components/camel-chunk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-clickup/pom.xml
+++ b/components/camel-clickup/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cloudevents/pom.xml
+++ b/components/camel-cloudevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cm-sms/pom.xml
+++ b/components/camel-cm-sms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cometd/pom.xml
+++ b/components/camel-cometd/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-consul/pom.xml
+++ b/components/camel-consul/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-controlbus/pom.xml
+++ b/components/camel-controlbus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-couchbase/pom.xml
+++ b/components/camel-couchbase/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-couchdb/pom.xml
+++ b/components/camel-couchdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cron/pom.xml
+++ b/components/camel-cron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-crypto-pgp/pom.xml
+++ b/components/camel-crypto-pgp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-crypto/pom.xml
+++ b/components/camel-crypto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-csimple-joor/pom.xml
+++ b/components/camel-csimple-joor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-csv/pom.xml
+++ b/components/camel-csv/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-blueprint/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-spring-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-transport-jetty/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-jetty/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cyberark-vault/pom.xml
+++ b/components/camel-cyberark-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dapr/pom.xml
+++ b/components/camel-dapr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dataformat/pom.xml
+++ b/components/camel-dataformat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dataset/pom.xml
+++ b/components/camel-dataset/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-datasonnet/pom.xml
+++ b/components/camel-datasonnet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-common/pom.xml
+++ b/components/camel-debezium/camel-debezium-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-db2/pom.xml
+++ b/components/camel-debezium/camel-debezium-db2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-mongodb/pom.xml
+++ b/components/camel-debezium/camel-debezium-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-postgres/pom.xml
+++ b/components/camel-debezium/camel-debezium-postgres/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-sqlserver/pom.xml
+++ b/components/camel-debezium/camel-debezium-sqlserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/pom.xml
+++ b/components/camel-debezium/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debug/pom.xml
+++ b/components/camel-debug/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dfdl/pom.xml
+++ b/components/camel-dfdl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dhis2/pom.xml
+++ b/components/camel-dhis2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-digitalocean/pom.xml
+++ b/components/camel-digitalocean/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-direct/pom.xml
+++ b/components/camel-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-directvm/pom.xml
+++ b/components/camel-directvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-disruptor/pom.xml
+++ b/components/camel-disruptor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dns/pom.xml
+++ b/components/camel-dns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-drill/pom.xml
+++ b/components/camel-drill/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dropbox/pom.xml
+++ b/components/camel-dropbox/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dsl-support/pom.xml
+++ b/components/camel-dsl-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dynamic-router/pom.xml
+++ b/components/camel-dynamic-router/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ehcache/pom.xml
+++ b/components/camel-ehcache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elasticsearch-rest-client/pom.xml
+++ b/components/camel-elasticsearch-rest-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elytron/pom.xml
+++ b/components/camel-elytron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-exec/pom.xml
+++ b/components/camel-exec/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fastjson/pom.xml
+++ b/components/camel-fastjson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fhir/pom.xml
+++ b/components/camel-fhir/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-file-watch/pom.xml
+++ b/components/camel-file-watch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-file/pom.xml
+++ b/components/camel-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flatpack/pom.xml
+++ b/components/camel-flatpack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flink/pom.xml
+++ b/components/camel-flink/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flowable/pom.xml
+++ b/components/camel-flowable/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fop/pom.xml
+++ b/components/camel-fop/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fory/pom.xml
+++ b/components/camel-fory/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-freemarker/pom.xml
+++ b/components/camel-freemarker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ftp/pom.xml
+++ b/components/camel-ftp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-geocoder/pom.xml
+++ b/components/camel-geocoder/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-git/pom.xml
+++ b/components/camel-git/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-github/pom.xml
+++ b/components/camel-github/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-github2/pom.xml
+++ b/components/camel-github2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-bigquery/pom.xml
+++ b/components/camel-google/camel-google-bigquery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-calendar/pom.xml
+++ b/components/camel-google/camel-google-calendar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-drive/pom.xml
+++ b/components/camel-google/camel-google-drive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-functions/pom.xml
+++ b/components/camel-google/camel-google-functions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-mail/pom.xml
+++ b/components/camel-google/camel-google-mail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-pubsub-lite/pom.xml
+++ b/components/camel-google/camel-google-pubsub-lite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-secret-manager/pom.xml
+++ b/components/camel-google/camel-google-secret-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-sheets/pom.xml
+++ b/components/camel-google/camel-google-sheets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-storage/pom.xml
+++ b/components/camel-google/camel-google-storage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-vertexai/pom.xml
+++ b/components/camel-google/camel-google-vertexai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/pom.xml
+++ b/components/camel-google/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grape/pom.xml
+++ b/components/camel-grape/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-graphql/pom.xml
+++ b/components/camel-graphql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grok/pom.xml
+++ b/components/camel-grok/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-groovy-xml/pom.xml
+++ b/components/camel-groovy-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-groovy/pom.xml
+++ b/components/camel-groovy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-gson/pom.xml
+++ b/components/camel-gson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-guava-eventbus/pom.xml
+++ b/components/camel-guava-eventbus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hashicorp-vault/pom.xml
+++ b/components/camel-hashicorp-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hazelcast/pom.xml
+++ b/components/camel-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-headersmap/pom.xml
+++ b/components/camel-headersmap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hl7/pom.xml
+++ b/components/camel-hl7/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http-base/pom.xml
+++ b/components/camel-http-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http-common/pom.xml
+++ b/components/camel-http-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http/pom.xml
+++ b/components/camel-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-common/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-dms/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-dms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-frs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-frs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-iam/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-iam/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-obs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-obs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-smn/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-smn/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/pom.xml
+++ b/components/camel-huawei/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-cos/pom.xml
+++ b/components/camel-ibm/camel-ibm-cos/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-secrets-manager/pom.xml
+++ b/components/camel-ibm/camel-ibm-secrets-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-discovery/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-language/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-language/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-speech-to-text/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-speech-to-text/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-text-to-speech/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-text-to-speech/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watsonx-ai/pom.xml
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/pom.xml
+++ b/components/camel-ibm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ical/pom.xml
+++ b/components/camel-ical/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iec60870/pom.xml
+++ b/components/camel-iec60870/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iggy/pom.xml
+++ b/components/camel-iggy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ignite/pom.xml
+++ b/components/camel-ignite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan-common/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan-embedded/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-embedded/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/camel-infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-influxdb/pom.xml
+++ b/components/camel-influxdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-influxdb2/pom.xml
+++ b/components/camel-influxdb2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-irc/pom.xml
+++ b/components/camel-irc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ironmq/pom.xml
+++ b/components/camel-ironmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iso8583/pom.xml
+++ b/components/camel-iso8583/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson-avro/pom.xml
+++ b/components/camel-jackson-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson-protobuf/pom.xml
+++ b/components/camel-jackson-protobuf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson/pom.xml
+++ b/components/camel-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jacksonxml/pom.xml
+++ b/components/camel-jacksonxml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jandex/pom.xml
+++ b/components/camel-jandex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jasypt/pom.xml
+++ b/components/camel-jasypt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-javascript/pom.xml
+++ b/components/camel-javascript/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jaxb/pom.xml
+++ b/components/camel-jaxb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jcache/pom.xml
+++ b/components/camel-jcache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jcr/pom.xml
+++ b/components/camel-jcr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jdbc/pom.xml
+++ b/components/camel-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jetty-common/pom.xml
+++ b/components/camel-jetty-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jetty/pom.xml
+++ b/components/camel-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jfr/pom.xml
+++ b/components/camel-jfr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jgroups-raft/pom.xml
+++ b/components/camel-jgroups-raft/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jgroups/pom.xml
+++ b/components/camel-jgroups/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jira/pom.xml
+++ b/components/camel-jira/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jms/pom.xml
+++ b/components/camel-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jmx/pom.xml
+++ b/components/camel-jmx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jolt/pom.xml
+++ b/components/camel-jolt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-joor/pom.xml
+++ b/components/camel-joor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jq/pom.xml
+++ b/components/camel-jq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsch/pom.xml
+++ b/components/camel-jsch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jslt/pom.xml
+++ b/components/camel-jslt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-json-patch/pom.xml
+++ b/components/camel-json-patch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-json-validator/pom.xml
+++ b/components/camel-json-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonapi/pom.xml
+++ b/components/camel-jsonapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonata/pom.xml
+++ b/components/camel-jsonata/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonb/pom.xml
+++ b/components/camel-jsonb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonpath/pom.xml
+++ b/components/camel-jsonpath/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jt400/pom.xml
+++ b/components/camel-jt400/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jta/pom.xml
+++ b/components/camel-jta/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jte/pom.xml
+++ b/components/camel-jte/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kamelet/pom.xml
+++ b/components/camel-kamelet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-keycloak/pom.xml
+++ b/components/camel-keycloak/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/camel-knative-http/pom.xml
+++ b/components/camel-knative/camel-knative-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-knative-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/camel-knative/pom.xml
+++ b/components/camel-knative/camel-knative/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-knative-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/pom.xml
+++ b/components/camel-knative/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kubernetes/pom.xml
+++ b/components/camel-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kudu/pom.xml
+++ b/components/camel-kudu/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-language/pom.xml
+++ b/components/camel-language/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ldap/pom.xml
+++ b/components/camel-ldap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ldif/pom.xml
+++ b/components/camel-ldif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-leveldb/pom.xml
+++ b/components/camel-leveldb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-log/pom.xml
+++ b/components/camel-log/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lra/pom.xml
+++ b/components/camel-lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lucene/pom.xml
+++ b/components/camel-lucene/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lumberjack/pom.xml
+++ b/components/camel-lumberjack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lzf/pom.xml
+++ b/components/camel-lzf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mail-microsoft-oauth/pom.xml
+++ b/components/camel-mail-microsoft-oauth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mapstruct/pom.xml
+++ b/components/camel-mapstruct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-master/pom.xml
+++ b/components/camel-master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mdc/pom.xml
+++ b/components/camel-mdc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-metrics/pom.xml
+++ b/components/camel-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer-observability/pom.xml
+++ b/components/camel-micrometer-observability/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer-prometheus/pom.xml
+++ b/components/camel-micrometer-prometheus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-config/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-health/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/pom.xml
+++ b/components/camel-microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-milo/pom.xml
+++ b/components/camel-milo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mina-sftp/pom.xml
+++ b/components/camel-mina-sftp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mina/pom.xml
+++ b/components/camel-mina/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-minio/pom.xml
+++ b/components/camel-minio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mllp/pom.xml
+++ b/components/camel-mllp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mock/pom.xml
+++ b/components/camel-mock/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mongodb-gridfs/pom.xml
+++ b/components/camel-mongodb-gridfs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mustache/pom.xml
+++ b/components/camel-mustache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mvel/pom.xml
+++ b/components/camel-mvel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mybatis/pom.xml
+++ b/components/camel-mybatis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-nats/pom.xml
+++ b/components/camel-nats/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-netty-http/pom.xml
+++ b/components/camel-netty-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-netty/pom.xml
+++ b/components/camel-netty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-nitrite/pom.xml
+++ b/components/camel-nitrite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-oaipmh/pom.xml
+++ b/components/camel-oaipmh/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-oauth/pom.xml
+++ b/components/camel-oauth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-observability-services/pom.xml
+++ b/components/camel-observability-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-observation/pom.xml
+++ b/components/camel-observation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ocsf/pom.xml
+++ b/components/camel-ocsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ognl/pom.xml
+++ b/components/camel-ognl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-olingo2/pom.xml
+++ b/components/camel-olingo2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-olingo4/pom.xml
+++ b/components/camel-olingo4/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-once/pom.xml
+++ b/components/camel-once/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openapi-java/pom.xml
+++ b/components/camel-openapi-java/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openapi-validator/pom.xml
+++ b/components/camel-openapi-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opensearch/pom.xml
+++ b/components/camel-opensearch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openstack/pom.xml
+++ b/components/camel-openstack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry-metrics/pom.xml
+++ b/components/camel-opentelemetry-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry/pom.xml
+++ b/components/camel-opentelemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry2/pom.xml
+++ b/components/camel-opentelemetry2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-paho-mqtt5/pom.xml
+++ b/components/camel-paho-mqtt5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-paho/pom.xml
+++ b/components/camel-paho/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-parquet-avro/pom.xml
+++ b/components/camel-parquet-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pdf/pom.xml
+++ b/components/camel-pdf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pg-replication-slot/pom.xml
+++ b/components/camel-pg-replication-slot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pgevent/pom.xml
+++ b/components/camel-pgevent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-jolokia/pom.xml
+++ b/components/camel-platform-http-jolokia/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-main/pom.xml
+++ b/components/camel-platform-http-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-vertx/pom.xml
+++ b/components/camel-platform-http-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http/pom.xml
+++ b/components/camel-platform-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-plc4x/pom.xml
+++ b/components/camel-plc4x/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pqc/pom.xml
+++ b/components/camel-pqc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-printer/pom.xml
+++ b/components/camel-printer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-protobuf/pom.xml
+++ b/components/camel-protobuf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pubnub/pom.xml
+++ b/components/camel-pubnub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pulsar/pom.xml
+++ b/components/camel-pulsar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-python/pom.xml
+++ b/components/camel-python/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-quartz/pom.xml
+++ b/components/camel-quartz/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-quickfix/pom.xml
+++ b/components/camel-quickfix/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-executor-tomcat/pom.xml
+++ b/components/camel-reactive-executor-tomcat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-executor-vertx/pom.xml
+++ b/components/camel-reactive-executor-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-streams/pom.xml
+++ b/components/camel-reactive-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactor/pom.xml
+++ b/components/camel-reactor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-redis/pom.xml
+++ b/components/camel-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ref/pom.xml
+++ b/components/camel-ref/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resilience4j-micrometer/pom.xml
+++ b/components/camel-resilience4j-micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resilience4j/pom.xml
+++ b/components/camel-resilience4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resourceresolver-github/pom.xml
+++ b/components/camel-resourceresolver-github/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rest/pom.xml
+++ b/components/camel-rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-robotframework/pom.xml
+++ b/components/camel-robotframework/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rocketmq/pom.xml
+++ b/components/camel-rocketmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rss/pom.xml
+++ b/components/camel-rss/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rxjava/pom.xml
+++ b/components/camel-rxjava/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-saga/pom.xml
+++ b/components/camel-saga/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-salesforce/pom.xml
+++ b/components/camel-salesforce/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sap-netweaver/pom.xml
+++ b/components/camel-sap-netweaver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-saxon/pom.xml
+++ b/components/camel-saxon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-scheduler/pom.xml
+++ b/components/camel-scheduler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-schematron/pom.xml
+++ b/components/camel-schematron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-seda/pom.xml
+++ b/components/camel-seda/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-service/pom.xml
+++ b/components/camel-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-servicenow/pom.xml
+++ b/components/camel-servicenow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-servlet/pom.xml
+++ b/components/camel-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-shiro/pom.xml
+++ b/components/camel-shiro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sjms/pom.xml
+++ b/components/camel-sjms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sjms2/pom.xml
+++ b/components/camel-sjms2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smb/pom.xml
+++ b/components/camel-smb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smooks/pom.xml
+++ b/components/camel-smooks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-snakeyaml/pom.xml
+++ b/components/camel-snakeyaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-snmp/pom.xml
+++ b/components/camel-snmp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-solr/pom.xml
+++ b/components/camel-solr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-splunk-hec/pom.xml
+++ b/components/camel-splunk-hec/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-splunk/pom.xml
+++ b/components/camel-splunk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-batch/pom.xml
+++ b/components/camel-spring-parent/camel-spring-batch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-cloud-config/pom.xml
+++ b/components/camel-spring-parent/camel-spring-cloud-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-jdbc/pom.xml
+++ b/components/camel-spring-parent/camel-spring-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-ldap/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ldap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-main/pom.xml
+++ b/components/camel-spring-parent/camel-spring-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-redis/pom.xml
+++ b/components/camel-spring-parent/camel-spring-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-security/pom.xml
+++ b/components/camel-spring-parent/camel-spring-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-ws/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-xml/pom.xml
+++ b/components/camel-spring-parent/camel-spring-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring/pom.xml
+++ b/components/camel-spring-parent/camel-spring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-undertow-spring-security/pom.xml
+++ b/components/camel-spring-parent/camel-undertow-spring-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/pom.xml
+++ b/components/camel-spring-parent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sql/pom.xml
+++ b/components/camel-sql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ssh/pom.xml
+++ b/components/camel-ssh/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stitch/pom.xml
+++ b/components/camel-stitch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stomp/pom.xml
+++ b/components/camel-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stream/pom.xml
+++ b/components/camel-stream/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stringtemplate/pom.xml
+++ b/components/camel-stringtemplate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stripe/pom.xml
+++ b/components/camel-stripe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stub/pom.xml
+++ b/components/camel-stub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-syslog/pom.xml
+++ b/components/camel-syslog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tahu/pom.xml
+++ b/components/camel-tahu/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tarfile/pom.xml
+++ b/components/camel-tarfile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telegram/pom.xml
+++ b/components/camel-telegram/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telemetry-dev/pom.xml
+++ b/components/camel-telemetry-dev/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telemetry/pom.xml
+++ b/components/camel-telemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-junit5/pom.xml
+++ b/components/camel-test/camel-test-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-junit6/pom.xml
+++ b/components/camel-test/camel-test-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-main-junit6/pom.xml
+++ b/components/camel-test/camel-test-main-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-spring-junit5/pom.xml
+++ b/components/camel-test/camel-test-spring-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-spring-junit6/pom.xml
+++ b/components/camel-test/camel-test-spring-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/pom.xml
+++ b/components/camel-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-threadpoolfactory-vertx/pom.xml
+++ b/components/camel-threadpoolfactory-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-thrift/pom.xml
+++ b/components/camel-thrift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-thymeleaf/pom.xml
+++ b/components/camel-thymeleaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tika/pom.xml
+++ b/components/camel-tika/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-timer/pom.xml
+++ b/components/camel-timer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tracing/pom.xml
+++ b/components/camel-tracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-twilio/pom.xml
+++ b/components/camel-twilio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-twitter/pom.xml
+++ b/components/camel-twitter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-univocity-parsers/pom.xml
+++ b/components/camel-univocity-parsers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-validator/pom.xml
+++ b/components/camel-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-velocity/pom.xml
+++ b/components/camel-velocity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-common/pom.xml
+++ b/components/camel-vertx/camel-vertx-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-http/pom.xml
+++ b/components/camel-vertx/camel-vertx-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-websocket/pom.xml
+++ b/components/camel-vertx/camel-vertx-websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx/pom.xml
+++ b/components/camel-vertx/camel-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/pom.xml
+++ b/components/camel-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vm/pom.xml
+++ b/components/camel-vm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-wal/pom.xml
+++ b/components/camel-wal/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-wasm/pom.xml
+++ b/components/camel-wasm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-weather/pom.xml
+++ b/components/camel-weather/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-web3j/pom.xml
+++ b/components/camel-web3j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-webhook/pom.xml
+++ b/components/camel-webhook/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-whatsapp/pom.xml
+++ b/components/camel-whatsapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-wordpress/pom.xml
+++ b/components/camel-wordpress/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-workday/pom.xml
+++ b/components/camel-workday/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xchange/pom.xml
+++ b/components/camel-xchange/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xj/pom.xml
+++ b/components/camel-xj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xml-io-dsl/pom.xml
+++ b/components/camel-xml-io-dsl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xmlsecurity/pom.xml
+++ b/components/camel-xmlsecurity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xmpp/pom.xml
+++ b/components/camel-xmpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xpath/pom.xml
+++ b/components/camel-xpath/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xslt-saxon/pom.xml
+++ b/components/camel-xslt-saxon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xslt/pom.xml
+++ b/components/camel-xslt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-yaml-dsl/pom.xml
+++ b/components/camel-yaml-dsl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zendesk/pom.xml
+++ b/components/camel-zendesk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zip-deflater/pom.xml
+++ b/components/camel-zip-deflater/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zipfile/pom.xml
+++ b/components/camel-zipfile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zookeeper-master/pom.xml
+++ b/components/camel-zookeeper-master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zookeeper/pom.xml
+++ b/components/camel-zookeeper/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-api/pom.xml
+++ b/core/camel-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-base-engine/pom.xml
+++ b/core/camel-base-engine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-base/pom.xml
+++ b/core/camel-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-cloud/pom.xml
+++ b/core/camel-cloud/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-cluster/pom.xml
+++ b/core/camel-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-console/pom.xml
+++ b/core/camel-console/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-catalog/pom.xml
+++ b/core/camel-core-catalog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-engine/pom.xml
+++ b/core/camel-core-engine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-languages/pom.xml
+++ b/core/camel-core-languages/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-model/pom.xml
+++ b/core/camel-core-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-processor/pom.xml
+++ b/core/camel-core-processor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-reifier/pom.xml
+++ b/core/camel-core-reifier/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-xml/pom.xml
+++ b/core/camel-core-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-health/pom.xml
+++ b/core/camel-health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-main/pom.xml
+++ b/core/camel-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-management-api/pom.xml
+++ b/core/camel-management-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-management/pom.xml
+++ b/core/camel-management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-support/pom.xml
+++ b/core/camel-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-tooling-model/pom.xml
+++ b/core/camel-tooling-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-util-json/pom.xml
+++ b/core/camel-util-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-util/pom.xml
+++ b/core/camel-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-io-util/pom.xml
+++ b/core/camel-xml-io-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-io/pom.xml
+++ b/core/camel-xml-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-jaxb/pom.xml
+++ b/core/camel-xml-jaxb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-jaxp/pom.xml
+++ b/core/camel-xml-jaxp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -2149,7 +2149,7 @@
         <bundle dependency='true'>wrap:mvn:org.apache.kafka/kafka-clients/${kafka-version}</bundle>
         <bundle dependency='true'>mvn:com.github.luben/zstd-jni/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/${auto-detect-version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.lz4/lz4-java/${auto-detect-version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.lz4/lz4-java/${lz4-java-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-kafka/${project.version}</bundle>
     </feature>
     <feature name='camel-kamelet' version='${project.version}' start-level='50'>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -715,6 +715,8 @@
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>mvn:org.jspecify/jspecify/${jspecify-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${reactor-netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty/reactor-netty-http/${auto-detect-version}$overwrite=merge&amp;Import-Package=io.netty.handler.codec.haproxy;resolution:=optional,io.netty.handler.codec.http3;resolution:=optional,io.netty.handler.codec.quic;resolution:=optional,io.netty.incubator.codec*;resolution:=optional,io.micrometer*;resolution:=optional,*</bundle>
@@ -765,6 +767,8 @@
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>mvn:org.jspecify/jspecify/${jspecify-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${reactor-netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty/reactor-netty-http/${auto-detect-version}$overwrite=merge&amp;Import-Package=io.netty.handler.codec.haproxy;resolution:=optional,io.netty.handler.codec.http3;resolution:=optional,io.netty.handler.codec.quic;resolution:=optional,io.netty.incubator.codec*;resolution:=optional,io.micrometer*;resolution:=optional,*</bundle>
@@ -2145,7 +2149,7 @@
         <bundle dependency='true'>wrap:mvn:org.apache.kafka/kafka-clients/${kafka-version}</bundle>
         <bundle dependency='true'>mvn:com.github.luben/zstd-jni/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/${auto-detect-version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.lz4/lz4-java/${lz4-java-version}</bundle>
+        <bundle dependency="true">wrap:mvn:at.yawk.lz4/lz4-java/${lz4-java-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-kafka/${project.version}</bundle>
     </feature>
     <feature name='camel-kamelet' version='${project.version}' start-level='50'>
@@ -3316,6 +3320,8 @@ Chain 2:
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty.incubator/reactor-netty-incubator-quic/${reactor-netty-incubator-quic-version}$overwrite=merge&amp;Import-Package=io.netty.channel.kqueue;resolution:=optional;version="[4.1,5)",io.netty.channel.uring;resolution:=optional;version="[4.1,5)",io.netty.incubator.channel.uring;resolution:=optional,io.netty*;version="[4.1,5)",*;resolution:=optional</bundle>
         <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${findbugs-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-stitch/${project.version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -103,7 +103,7 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
         <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
         <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}$overwrite=merge</bundle>
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-annotations-version}</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
     </feature>
 
     <feature name="jackson" version="${jackson216-version}">

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -154,6 +154,7 @@
     <feature name="netty" version="${netty-version}">
         <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-base/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -154,8 +154,7 @@
     <feature name="netty" version="${netty-version}">
         <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-base/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-compression/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -155,6 +155,7 @@
         <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-base/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-compression/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-handler/${netty-version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -103,7 +103,7 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
         <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
         <bundle dependency='true'>wrap:mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}$overwrite=merge</bundle>
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-annotations-version}</bundle>
     </feature>
 
     <feature name="jackson" version="${jackson216-version}">
@@ -715,8 +715,6 @@
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>mvn:org.jspecify/jspecify/${jspecify-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${reactor-netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty/reactor-netty-http/${auto-detect-version}$overwrite=merge&amp;Import-Package=io.netty.handler.codec.haproxy;resolution:=optional,io.netty.handler.codec.http3;resolution:=optional,io.netty.handler.codec.quic;resolution:=optional,io.netty.incubator.codec*;resolution:=optional,io.micrometer*;resolution:=optional,*</bundle>
@@ -767,8 +765,6 @@
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>mvn:org.jspecify/jspecify/${jspecify-version}</bundle>
         <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${reactor-netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty/reactor-netty-http/${auto-detect-version}$overwrite=merge&amp;Import-Package=io.netty.handler.codec.haproxy;resolution:=optional,io.netty.handler.codec.http3;resolution:=optional,io.netty.handler.codec.quic;resolution:=optional,io.netty.incubator.codec*;resolution:=optional,io.micrometer*;resolution:=optional,*</bundle>
@@ -3320,8 +3316,6 @@ Chain 2:
         <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-http3/${netty-version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-classes-quic/${netty-version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.projectreactor.netty.incubator/reactor-netty-incubator-quic/${reactor-netty-incubator-quic-version}$overwrite=merge&amp;Import-Package=io.netty.channel.kqueue;resolution:=optional;version="[4.1,5)",io.netty.channel.uring;resolution:=optional;version="[4.1,5)",io.netty.incubator.channel.uring;resolution:=optional,io.netty*;version="[4.1,5)",*;resolution:=optional</bundle>
         <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${findbugs-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-stitch/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <asm-version>9.9.1</asm-version>
         <asn1bean-version>1.14.0</asn1bean-version>
         <assertj-version>3.27.7</assertj-version>
+        <async-http-client-version>3.0.3</async-http-client-version>
         <asterisk-java-version>3.41.0</asterisk-java-version>
         <atlassian-fugue-version>6.1.2</atlassian-fugue-version>
         <atmosphere-version>3.1.0</atmosphere-version>
@@ -182,7 +183,10 @@
         <disruptor-version>3.4.4</disruptor-version>
         <dnsjava-version>3.6.4</dnsjava-version>
         <djl-version>0.36.0</djl-version>
+        <docling-core-version>0.4.4</docling-core-version>
         <docling-java-version>0.4.4</docling-java-version>
+        <docling-serve-api-version>0.4.4</docling-serve-api-version>
+        <docling-serve-client-version>0.4.4</docling-serve-client-version>
         <docker-java-version>3.7.0</docker-java-version>
         <dropbox-version>7.0.0</dropbox-version>
         <eddsa-version>0.3.0</eddsa-version>
@@ -377,7 +381,9 @@
         <kudu-version>1.18.1</kudu-version>
         <langchain4j-version>1.11.0</langchain4j-version>
         <langchain4j-beta-version>1.11.0-beta19</langchain4j-beta-version>
+        <langchain4j-community-dashscope-version>1.11.0-beta19</langchain4j-community-dashscope-version>
         <langchain4j-community-version>1.11.0-beta19</langchain4j-community-version>
+        <langchain4j-hugging-face-version>1.11.0-beta19</langchain4j-hugging-face-version>
         <leveldbjni-version>1.8</leveldbjni-version>
         <leveldb-api-version>0.12</leveldb-api-version>
         <leveldb-version>0.12</leveldb-version>
@@ -411,6 +417,8 @@
         <mybatis-version>3.5.19</mybatis-version>
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
+        <microprofile-fault-tolerance-version>4.1.2</microprofile-fault-tolerance-version>
+        <neo4j-bolt-version>6.0.2</neo4j-bolt-version>
         <neo4j-version>6.0.2</neo4j-version>
         <netty-version>4.1.131.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
@@ -465,6 +473,7 @@
         <quickfixj-version>2.3.2</quickfixj-version>
         <reactive-streams-version>1.0.4</reactive-streams-version>
         <reactor-version>3.8.3</reactor-version>
+        <reactor-netty-incubator-quic-version>0.1.20</reactor-netty-incubator-quic-version>
         <reactor-netty-version>1.3.3</reactor-netty-version>
         <redisson-version>3.52.0</redisson-version>
         <resilience4j-version>2.3.0</resilience4j-version>
@@ -561,7 +570,7 @@
         <!-- OSGI version ranges -->
         <camel-osgi-asm-version>[9.5,10)</camel-osgi-asm-version>
         <camel-osgi-cglib-version>[3.3,3.4)</camel-osgi-cglib-version>
-        <camel-osgi-jackson2-version>[2.20,2.21)</camel-osgi-jackson2-version>
+        <camel-osgi-jackson2-version>[2.19,2.20)</camel-osgi-jackson2-version>
         <camel-osgi-jakarta-annotation2-version>[2,3)</camel-osgi-jakarta-annotation2-version>
         <camel-osgi-jakarta-annotation-version>[3,4)</camel-osgi-jakarta-annotation-version>
         <camel-osgi-jakarta-activation-version>[2.1,3)</camel-osgi-jakarta-activation-version>

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <microprofile-fault-tolerance-version>4.1.2</microprofile-fault-tolerance-version>
         <neo4j-bolt-version>6.0.2</neo4j-bolt-version>
         <neo4j-version>6.0.2</neo4j-version>
-        <netty-version>4.1.131.Final</netty-version>
+        <netty-version>4.2.12.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.9</networknt-json-schema-validator-version>
         <nimbusds-content-type-version>2.3</nimbusds-content-type-version>
@@ -503,6 +503,7 @@
         <smooks-version>2.2.1</smooks-version>
         <snakeyaml-version>2.5</snakeyaml-version>
         <snakeyaml-engine-version>3.0.1</snakeyaml-engine-version>
+        <snakeyaml-engine-kubernetes-version>2.10</snakeyaml-engine-kubernetes-version>
         <snmp4j-version>3.9.7</snmp4j-version>
         <solr-version>9.10.1</solr-version>
         <solr-zookeeper-version>3.9.5</solr-zookeeper-version>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
         <jackson-databind-nullable-version>0.2.9</jackson-databind-nullable-version>
         <jackson-jq-version>1.6.0</jackson-jq-version>
         <jackson2-version>2.20.1</jackson2-version>
+        <jackson2-annotations-version>2.20</jackson2-annotations-version>
         <jackrabbit-version>2.22.3</jackrabbit-version>
         <jasminb-jsonapi-version>0.15</jasminb-jsonapi-version>
         <jandex-version>3.5.3</jandex-version>
@@ -363,6 +364,7 @@
         <json-patch-version>1.13</json-patch-version>
         <json-smart-version>2.6.0</json-smart-version>
         <jsonata-version>0.9.9</jsonata-version>
+        <jspecify-version>1.0.0</jspecify-version>
         <json-unit-version>5.1.0</json-unit-version>
         <jsoup-version>1.22.1</jsoup-version>
         <jt400-version>21.0.6</jt400-version>
@@ -423,6 +425,9 @@
         <netty-version>4.1.131.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.9</networknt-json-schema-validator-version>
+        <nimbusds-content-type-version>2.3</nimbusds-content-type-version>
+        <nimbusds-lang-tag-version>1.7</nimbusds-lang-tag-version>
+        <nimbusds-oauth2-oidc-sdk-version>11.23</nimbusds-oauth2-oidc-sdk-version>
         <nimbus-jose-jwt>10.7</nimbus-jose-jwt>
         <nitrite-version>3.4.4</nitrite-version>
         <olingo2-version>2.0.13</olingo2-version>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <ivy-version>2.5.3</ivy-version>
         <jackson-databind-nullable-version>0.2.9</jackson-databind-nullable-version>
         <jackson-jq-version>1.6.0</jackson-jq-version>
-        <jackson2-version>2.19.4</jackson2-version>
+        <jackson2-version>2.20.1</jackson2-version>
         <jackrabbit-version>2.22.3</jackrabbit-version>
         <jasminb-jsonapi-version>0.15</jasminb-jsonapi-version>
         <jandex-version>3.5.3</jandex-version>
@@ -570,7 +570,7 @@
         <!-- OSGI version ranges -->
         <camel-osgi-asm-version>[9.5,10)</camel-osgi-asm-version>
         <camel-osgi-cglib-version>[3.3,3.4)</camel-osgi-cglib-version>
-        <camel-osgi-jackson2-version>[2.19,2.20)</camel-osgi-jackson2-version>
+        <camel-osgi-jackson2-version>[2.20,3.0)</camel-osgi-jackson2-version>
         <camel-osgi-jakarta-annotation2-version>[2,3)</camel-osgi-jakarta-annotation2-version>
         <camel-osgi-jakarta-annotation-version>[3,4)</camel-osgi-jakarta-annotation-version>
         <camel-osgi-jakarta-activation-version>[2.1,3)</camel-osgi-jakarta-activation-version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.camel.karaf</groupId>
     <artifactId>camel-karaf</artifactId>
-    <version>4.18.0-SNAPSHOT</version>
+    <version>4.18.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Camel :: Karaf</name>
@@ -90,11 +90,11 @@
         <javaVersion>17</javaVersion>
         <project.build.outputTimestamp>1773392261</project.build.outputTimestamp>
 
-        <camel-version>4.18.0</camel-version>
+        <camel-version>4.18.1</camel-version>
 
         <!-- START: Maven Properties defining the version of 3rd party libraries used in Camel -->
-        <activemq-version>5.19.1</activemq-version>
-        <activemq6-version>6.2.0</activemq6-version>
+        <activemq-version>5.19.2</activemq-version>
+        <activemq6-version>6.2.1</activemq6-version>
         <activemq-artemis-version>2.44.0</activemq-artemis-version>
         <allegro-converter-version>0.3.0</allegro-converter-version>
         <amazon-kinesis-client-version>2.6.0</amazon-kinesis-client-version>
@@ -123,7 +123,7 @@
         <box-java-sdk-version>4.16.3</box-java-sdk-version>
         <braintree-gateway-version>3.48.0</braintree-gateway-version>
         <bytebuddy-version>1.18.4</bytebuddy-version>
-        <c3p0-version>0.11.2</c3p0-version>
+        <c3p0-version>0.12.0</c3p0-version>
         <caffeine-version>3.2.3</caffeine-version>
         <californium-version>3.14.0</californium-version>
         <californium-scandium-version>3.11.0</californium-scandium-version>
@@ -136,7 +136,7 @@
         <checker-framework-version>3.53.1</checker-framework-version>
         <chicory-version>1.6.1</chicory-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
-        <citrus-version>4.9.2</citrus-version>
+        <citrus-version>4.10.0</citrus-version>
         <classgraph-version>4.8.184</classgraph-version>
         <cloudant-version>0.10.15</cloudant-version>
         <com-ibm-mq-jakarta-client-version>9.4.5.0</com-ibm-mq-jakarta-client-version>
@@ -165,8 +165,8 @@
         <consul-client-version>1.9.2</consul-client-version>
         <couchbase-client-version>3.11.0</couchbase-client-version>
         <curator-version>5.9.0</curator-version>
-        <cxf-version>4.1.4</cxf-version>
-        <cxf-codegen-plugin-version>4.1.4</cxf-codegen-plugin-version>
+        <cxf-version>4.1.5</cxf-version>
+        <cxf-codegen-plugin-version>4.1.5</cxf-codegen-plugin-version>
         <cxf-xjc-plugin-version>4.1.2</cxf-xjc-plugin-version>
         <cxf-xjc-utils-version>4.1.2</cxf-xjc-utils-version>
         <daffodil-version>3.10.0</daffodil-version>
@@ -182,9 +182,7 @@
         <disruptor-version>3.4.4</disruptor-version>
         <dnsjava-version>3.6.4</dnsjava-version>
         <djl-version>0.36.0</djl-version>
-        <docling-core-version>0.4.4</docling-core-version>
-        <docling-serve-api-version>0.4.4</docling-serve-api-version>
-        <docling-serve-client-version>0.4.4</docling-serve-client-version>
+        <docling-java-version>0.4.4</docling-java-version>
         <docker-java-version>3.7.0</docker-java-version>
         <dropbox-version>7.0.0</dropbox-version>
         <eddsa-version>0.3.0</eddsa-version>
@@ -295,8 +293,7 @@
         <ivy-version>2.5.3</ivy-version>
         <jackson-databind-nullable-version>0.2.9</jackson-databind-nullable-version>
         <jackson-jq-version>1.6.0</jackson-jq-version>
-        <jackson2-version>2.20.1</jackson2-version>
-        <jackson2-annotations-version>2.20</jackson2-annotations-version>
+        <jackson2-version>2.19.4</jackson2-version>
         <jackrabbit-version>2.22.3</jackrabbit-version>
         <jasminb-jsonapi-version>0.15</jasminb-jsonapi-version>
         <jandex-version>3.5.3</jandex-version>
@@ -348,7 +345,7 @@
         <jolokia-version>2.5.0</jolokia-version>
         <jolt-version>0.1.8</jolt-version>
         <jool-version>0.9.15</jool-version>
-        <jooq-version>3.19.22</jooq-version>
+        <jooq-version>3.19.30</jooq-version>
         <joor-version>0.9.15</joor-version>
         <jose4j-version>0.9.3</jose4j-version>
         <johnzon-version>2.0.2</johnzon-version>
@@ -362,7 +359,6 @@
         <json-patch-version>1.13</json-patch-version>
         <json-smart-version>2.6.0</json-smart-version>
         <jsonata-version>0.9.9</jsonata-version>
-        <jspecify-version>1.0.0</jspecify-version>
         <json-unit-version>5.1.0</json-unit-version>
         <jsoup-version>1.22.1</jsoup-version>
         <jt400-version>21.0.6</jt400-version>
@@ -375,32 +371,29 @@
         <jxmpp-version>1.1.0</jxmpp-version>
         <jython-version>2.7.4</jython-version>
         <jzlib-version>1.1.3</jzlib-version>
-        <kafka-version>3.9.1</kafka-version>
+        <kafka-version>3.9.2</kafka-version>
         <keycloak-client-version>26.0.8</keycloak-client-version>
         <kubernetes-client-version>7.5.2</kubernetes-client-version>
         <kudu-version>1.18.1</kudu-version>
         <langchain4j-version>1.11.0</langchain4j-version>
         <langchain4j-beta-version>1.11.0-beta19</langchain4j-beta-version>
         <langchain4j-community-version>1.11.0-beta19</langchain4j-community-version>
-        <langchain4j-hugging-face-version>1.11.0-beta19</langchain4j-hugging-face-version>
-        <langchain4j-community-dashscope-version>1.11.0-beta19</langchain4j-community-dashscope-version>
         <leveldbjni-version>1.8</leveldbjni-version>
         <leveldb-api-version>0.12</leveldb-api-version>
         <leveldb-version>0.12</leveldb-version>
         <libphonenumber-version>9.0.23</libphonenumber-version>
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
         <log4j2-version>2.25.3</log4j2-version>
-        <logback-version>1.5.29</logback-version>
+        <logback-version>1.5.32</logback-version>
         <lucene-version>9.12.3</lucene-version>
         <lightcouch-version>0.2.0</lightcouch-version>
         <littleproxy-version>2.6.0</littleproxy-version>
         <lz4-java-version>1.10.3</lz4-java-version>
         <mapstruct-version>1.6.3</mapstruct-version>
         <metrics-version>4.2.38</metrics-version>
-        <micrometer-version>1.15.6</micrometer-version>
-        <micrometer-tracing-version>1.5.5</micrometer-tracing-version>
+        <micrometer-version>1.15.10</micrometer-version>
+        <micrometer-tracing-version>1.5.10</micrometer-tracing-version>
         <microprofile-config-version>3.1</microprofile-config-version>
-        <microprofile-fault-tolerance-version>4.1.2</microprofile-fault-tolerance-version>
         <milo-version>1.1.1</milo-version>
         <milvus-client-version>2.6.14</milvus-client-version>
         <mina-version>2.2.5</mina-version>
@@ -419,13 +412,9 @@
         <narayana-version>5.13.1.Final</narayana-version>
         <neoscada-version>0.4.0</neoscada-version>
         <neo4j-version>6.0.2</neo4j-version>
-        <neo4j-bolt-version>6.0.2</neo4j-bolt-version>
-        <netty-version>4.2.10.Final</netty-version>
+        <netty-version>4.1.131.Final</netty-version>
         <netty-reactive-streams-version>2.0.5</netty-reactive-streams-version>
         <networknt-json-schema-validator-version>1.5.9</networknt-json-schema-validator-version>
-        <nimbusds-content-type-version>2.3</nimbusds-content-type-version>
-        <nimbusds-lang-tag-version>1.7</nimbusds-lang-tag-version>
-        <nimbusds-oauth2-oidc-sdk-version>11.23</nimbusds-oauth2-oidc-sdk-version>
         <nimbus-jose-jwt>10.7</nimbus-jose-jwt>
         <nitrite-version>3.4.4</nitrite-version>
         <olingo2-version>2.0.13</olingo2-version>
@@ -477,10 +466,9 @@
         <reactive-streams-version>1.0.4</reactive-streams-version>
         <reactor-version>3.8.3</reactor-version>
         <reactor-netty-version>1.3.3</reactor-netty-version>
-        <reactor-netty-incubator-quic-version>0.1.20</reactor-netty-incubator-quic-version>
         <redisson-version>3.52.0</redisson-version>
         <resilience4j-version>2.3.0</resilience4j-version>
-        <rest-assured-version>5.5.6</rest-assured-version>
+        <rest-assured-version>5.5.7</rest-assured-version>
         <roaster-version>2.31.0.Final</roaster-version>
         <robotframework-version>4.1.2</robotframework-version>
         <rocketmq-version>5.3.2</rocketmq-version>
@@ -501,24 +489,22 @@
         <smooks-version>2.2.1</smooks-version>
         <snakeyaml-version>2.5</snakeyaml-version>
         <snakeyaml-engine-version>3.0.1</snakeyaml-engine-version>
-        <!-- fabric8 kubernetes-client 7.x imports snakeyaml-engine [2.10,3), so we pin to 2.x for kubernetes -->
-        <snakeyaml-engine-kubernetes-version>2.10</snakeyaml-engine-kubernetes-version>
         <snmp4j-version>3.9.7</snmp4j-version>
         <solr-version>9.10.1</solr-version>
-        <solr-zookeeper-version>3.9.4</solr-zookeeper-version>
+        <solr-zookeeper-version>3.9.5</solr-zookeeper-version>
         <splunk-version>1.9.5_1</splunk-version>
         <spock-version>2.4-groovy-4.0</spock-version>
         <spring-ai-version>1.1.2</spring-ai-version>
         <spring-cloud-config-version>4.3.0</spring-cloud-config-version>
-        <spring-batch-version>5.2.4</spring-batch-version>
-        <spring-boot-version>3.5.10</spring-boot-version>
+        <spring-batch-version>5.2.5</spring-batch-version>
+        <spring-boot-version>3.5.12</spring-boot-version>
         <spring-data-redis-version>3.5.5</spring-data-redis-version>
-        <spring-ldap-version>3.3.5</spring-ldap-version>
+        <spring-ldap-version>3.3.6</spring-ldap-version>
         <spring-vault-core-version>3.2.0</spring-vault-core-version>
-        <spring-version>6.2.15</spring-version>
-        <spring-rabbitmq-version>3.2.8</spring-rabbitmq-version>
-        <spring-security-version>6.5.7</spring-security-version>
-        <spring-ws-version>4.1.2</spring-ws-version>
+        <spring-version>6.2.17</spring-version>
+        <spring-rabbitmq-version>3.2.9</spring-rabbitmq-version>
+        <spring-security-version>6.5.9</spring-security-version>
+        <spring-ws-version>4.1.3</spring-ws-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okhttp5-version>5.3.2</squareup-okhttp5-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>
@@ -545,7 +531,7 @@
         <vavr-version>1.0.0</vavr-version>
         <velocity-tools-version>3.1</velocity-tools-version>
         <velocity-version>2.4.1</velocity-version>
-        <vertx-version>4.5.24</vertx-version>
+        <vertx-version>4.5.25</vertx-version>
         <vysper-version>0.7</vysper-version>
         <weaviate-client-version>5.5.0</weaviate-client-version>
         <web3j-version>5.0.0</web3j-version>
@@ -567,9 +553,8 @@
         <yasson-version>3.0.4</yasson-version>
         <yetus-audience-annotations-version>0.15.1</yetus-audience-annotations-version>
         <zeebe-version>8.8.11</zeebe-version>
-        <async-http-client-version>3.0.3</async-http-client-version>
         <zendesk-client-version>1.4.0</zendesk-client-version>
-        <zookeeper-version>3.9.4</zookeeper-version>
+        <zookeeper-version>3.9.5</zookeeper-version>
         <zxing-version>3.5.4</zxing-version>
         <!-- END: Maven Properties defining the version of 3rd party libraries used in Camel -->
 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-blueprint-main/pom.xml
+++ b/tests/camel-blueprint-main/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-integration-test/pom.xml
+++ b/tests/camel-integration-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-test-blueprint-junit5/pom.xml
+++ b/tests/camel-test-blueprint-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-test-scr/pom.xml
+++ b/tests/camel-test-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/examples/blueprint-dsl-only/pom.xml
+++ b/tests/examples/blueprint-dsl-only/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-blueprint-dsl-only-test</artifactId>

--- a/tests/examples/java-dsl-only/pom.xml
+++ b/tests/examples/java-dsl-only/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-java-dsl-only-test</artifactId>

--- a/tests/examples/mixed/pom.xml
+++ b/tests/examples/mixed/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-mixed-test</artifactId>

--- a/tests/examples/pom.xml
+++ b/tests/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-activemq/pom.xml
+++ b/tests/features/camel-activemq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-activemq-test</artifactId>

--- a/tests/features/camel-amqp/pom.xml
+++ b/tests/features/camel-amqp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-amqp-test</artifactId>

--- a/tests/features/camel-arangodb/pom.xml
+++ b/tests/features/camel-arangodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-as2/pom.xml
+++ b/tests/features/camel-as2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-as2-test</artifactId>

--- a/tests/features/camel-asn1/pom.xml
+++ b/tests/features/camel-asn1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-asn1-test</artifactId>

--- a/tests/features/camel-atom/pom.xml
+++ b/tests/features/camel-atom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-atom-test</artifactId>

--- a/tests/features/camel-avro/pom.xml
+++ b/tests/features/camel-avro/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-avro-test</artifactId>

--- a/tests/features/camel-aws2-iam/pom.xml
+++ b/tests/features/camel-aws2-iam/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-iam-test</artifactId>

--- a/tests/features/camel-aws2-kinesis/pom.xml
+++ b/tests/features/camel-aws2-kinesis/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-kinesis-test</artifactId>

--- a/tests/features/camel-aws2-s3/pom.xml
+++ b/tests/features/camel-aws2-s3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-s3-test</artifactId>

--- a/tests/features/camel-aws2-ses/pom.xml
+++ b/tests/features/camel-aws2-ses/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-ses-test</artifactId>

--- a/tests/features/camel-aws2-sns/pom.xml
+++ b/tests/features/camel-aws2-sns/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sns-test</artifactId>

--- a/tests/features/camel-aws2-sqs/pom.xml
+++ b/tests/features/camel-aws2-sqs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sqs-test</artifactId>

--- a/tests/features/camel-aws2-sts/pom.xml
+++ b/tests/features/camel-aws2-sts/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sts-test</artifactId>

--- a/tests/features/camel-azure-eventhubs/pom.xml
+++ b/tests/features/camel-azure-eventhubs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-eventhubs-test</artifactId>

--- a/tests/features/camel-azure-storage-blob/pom.xml
+++ b/tests/features/camel-azure-storage-blob/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-storage-blob-test</artifactId>

--- a/tests/features/camel-azure-storage-queue/pom.xml
+++ b/tests/features/camel-azure-storage-queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-storage-queue-test</artifactId>

--- a/tests/features/camel-barcode/pom.xml
+++ b/tests/features/camel-barcode/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-barcode-test</artifactId>

--- a/tests/features/camel-base64/pom.xml
+++ b/tests/features/camel-base64/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-base64-test</artifactId>

--- a/tests/features/camel-bean-validator/pom.xml
+++ b/tests/features/camel-bean-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-bean-validator-test</artifactId>

--- a/tests/features/camel-bindy/pom.xml
+++ b/tests/features/camel-bindy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-bindy-test</artifactId>

--- a/tests/features/camel-caffeine/pom.xml
+++ b/tests/features/camel-caffeine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-caffeine-test</artifactId>

--- a/tests/features/camel-cbor/pom.xml
+++ b/tests/features/camel-cbor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cbor-test</artifactId>

--- a/tests/features/camel-chatscript/pom.xml
+++ b/tests/features/camel-chatscript/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-chatscript-test</artifactId>

--- a/tests/features/camel-coap/pom.xml
+++ b/tests/features/camel-coap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-coap-test</artifactId>

--- a/tests/features/camel-cometd/pom.xml
+++ b/tests/features/camel-cometd/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cometd-test</artifactId>

--- a/tests/features/camel-consul/pom.xml
+++ b/tests/features/camel-consul/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-consul-test</artifactId>

--- a/tests/features/camel-core/pom.xml
+++ b/tests/features/camel-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-couchdb/pom.xml
+++ b/tests/features/camel-couchdb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-couchdb-test</artifactId>

--- a/tests/features/camel-crypto/pom.xml
+++ b/tests/features/camel-crypto/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-crypto-test</artifactId>

--- a/tests/features/camel-csv/pom.xml
+++ b/tests/features/camel-csv/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-csv-test</artifactId>

--- a/tests/features/camel-cxf-jetty/pom.xml
+++ b/tests/features/camel-cxf-jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cxf-jetty-test</artifactId>

--- a/tests/features/camel-cxf/pom.xml
+++ b/tests/features/camel-cxf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cxf-test</artifactId>

--- a/tests/features/camel-debezium-mongodb/pom.xml
+++ b/tests/features/camel-debezium-mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-mongodb-test</artifactId>

--- a/tests/features/camel-debezium-mysql/pom.xml
+++ b/tests/features/camel-debezium-mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-mysql-test</artifactId>

--- a/tests/features/camel-debezium-postgres/pom.xml
+++ b/tests/features/camel-debezium-postgres/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-postgres-test</artifactId>

--- a/tests/features/camel-disruptor/pom.xml
+++ b/tests/features/camel-disruptor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-disruptor-test</artifactId>

--- a/tests/features/camel-dns/pom.xml
+++ b/tests/features/camel-dns/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-dns-test</artifactId>

--- a/tests/features/camel-docker/pom.xml
+++ b/tests/features/camel-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-docker-test</artifactId>

--- a/tests/features/camel-drill/pom.xml
+++ b/tests/features/camel-drill/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-drill-test</artifactId>

--- a/tests/features/camel-ehcache/pom.xml
+++ b/tests/features/camel-ehcache/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-ehcache-test</artifactId>

--- a/tests/features/camel-elasticsearch/pom.xml
+++ b/tests/features/camel-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-exec/pom.xml
+++ b/tests/features/camel-exec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-exec-test</artifactId>

--- a/tests/features/camel-fastjson/pom.xml
+++ b/tests/features/camel-fastjson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-fastjson-test</artifactId>

--- a/tests/features/camel-flatpack/pom.xml
+++ b/tests/features/camel-flatpack/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-flatpack-test</artifactId>

--- a/tests/features/camel-ftp/pom.xml
+++ b/tests/features/camel-ftp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-ftp-test</artifactId>

--- a/tests/features/camel-google-pubsub/pom.xml
+++ b/tests/features/camel-google-pubsub/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-groovy/pom.xml
+++ b/tests/features/camel-groovy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-groovy-test</artifactId>

--- a/tests/features/camel-gson/pom.xml
+++ b/tests/features/camel-gson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-gson-test</artifactId>

--- a/tests/features/camel-hazelcast/pom.xml
+++ b/tests/features/camel-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-hazelcast-test</artifactId>

--- a/tests/features/camel-http/pom.xml
+++ b/tests/features/camel-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-http-test</artifactId>

--- a/tests/features/camel-influxdb2/pom.xml
+++ b/tests/features/camel-influxdb2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-influxdb2-test</artifactId>

--- a/tests/features/camel-jackson-avro/pom.xml
+++ b/tests/features/camel-jackson-avro/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-avro-test</artifactId>

--- a/tests/features/camel-jackson-protobuf/pom.xml
+++ b/tests/features/camel-jackson-protobuf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-protobuf-test</artifactId>

--- a/tests/features/camel-jackson/pom.xml
+++ b/tests/features/camel-jackson/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2-annotations-version}</version>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-jackson/pom.xml
+++ b/tests/features/camel-jackson/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson2-annotations-version}</version>
+            <version>${jackson2-version}</version>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-jackson/pom.xml
+++ b/tests/features/camel-jackson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-test</artifactId>

--- a/tests/features/camel-jacksonxml/pom.xml
+++ b/tests/features/camel-jacksonxml/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson2-version}</version>
+            <version>${jackson2-annotations-version}</version>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-jacksonxml/pom.xml
+++ b/tests/features/camel-jacksonxml/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson2-annotations-version}</version>
+            <version>${jackson2-version}</version>
         </dependency>
     </dependencies>
 

--- a/tests/features/camel-jacksonxml/pom.xml
+++ b/tests/features/camel-jacksonxml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jacksonxml-test</artifactId>

--- a/tests/features/camel-jaxb/pom.xml
+++ b/tests/features/camel-jaxb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jaxb-test</artifactId>

--- a/tests/features/camel-jcache/pom.xml
+++ b/tests/features/camel-jcache/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jcache-test</artifactId>

--- a/tests/features/camel-jetty/pom.xml
+++ b/tests/features/camel-jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jetty-test</artifactId>

--- a/tests/features/camel-jms/pom.xml
+++ b/tests/features/camel-jms/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jms-test</artifactId>

--- a/tests/features/camel-kafka/pom.xml
+++ b/tests/features/camel-kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-kafka-test</artifactId>

--- a/tests/features/camel-leveldb/pom.xml
+++ b/tests/features/camel-leveldb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-leveldb-test</artifactId>

--- a/tests/features/camel-mail/pom.xml
+++ b/tests/features/camel-mail/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-mail-test</artifactId>

--- a/tests/features/camel-netty-http/pom.xml
+++ b/tests/features/camel-netty-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-netty-http-test</artifactId>

--- a/tests/features/camel-olingo2/pom.xml
+++ b/tests/features/camel-olingo2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-olingo2-test</artifactId>

--- a/tests/features/camel-paho-mqtt5/pom.xml
+++ b/tests/features/camel-paho-mqtt5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-paho-mqtt5-test</artifactId>

--- a/tests/features/camel-quartz/pom.xml
+++ b/tests/features/camel-quartz/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quartz-test</artifactId>

--- a/tests/features/camel-saxon/pom.xml
+++ b/tests/features/camel-saxon/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-saxon-test</artifactId>

--- a/tests/features/camel-spring-rabbitmq/pom.xml
+++ b/tests/features/camel-spring-rabbitmq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-spring-rabbitmq-test</artifactId>

--- a/tests/features/camel-velocity/pom.xml
+++ b/tests/features/camel-velocity/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-velocity-test</artifactId>

--- a/tests/features/camel-weather/pom.xml
+++ b/tests/features/camel-weather/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-weather-test</artifactId>

--- a/tests/features/camel-xslt-saxon/pom.xml
+++ b/tests/features/camel-xslt-saxon/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-xslt-saxon-test</artifactId>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tooling/camel-karaf-feature-maven-plugin/pom.xml
+++ b/tooling/camel-karaf-feature-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
     
     <artifactId>camel-karaf-feature-maven-plugin</artifactId>

--- a/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
     
     <artifactId>camel-karaf-maven-plugin-integration-test</artifactId>

--- a/tooling/camel-karaf-test-feature-archetype/pom.xml
+++ b/tooling/camel-karaf-test-feature-archetype/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-test-feature-archetype</artifactId>

--- a/tooling/camel-upgrade/pom.xml
+++ b/tooling/camel-upgrade/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-upgrade</artifactId>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.0-SNAPSHOT</version>
+        <version>4.18.1-SNAPSHOT</version>
     </parent>
     
     <artifactId>tooling</artifactId>


### PR DESCRIPTION
## Changes

- Upgrade all component versions to Camel 4.18.1

## Bug fixes

- Fix `camel-osgi-jackson2-version` range from `[2.20,2.21)` to `[2.19,2.20)` to match `jackson2-version` 2.19.4 used by Camel 4.18.1
- Restore missing version properties accidentally dropped during upgrade: `docling-core-version`, `docling-serve-api-version`, `docling-serve-client-version`, `langchain4j-hugging-face-version`, `langchain4j-community-dashscope-version`, `microprofile-fault-tolerance-version`, `neo4j-bolt-version`, `reactor-netty-incubator-quic-version`, `async-http-client-version`
- Fix `camel-kafka` feature to use explicit `lz4-java-version` instead of `auto-detect-version` which failed version resolution