### PR TITLE
fix(#707): Add simple-no-file language support (backport of #708)

### DIFF
--- a/core/camel-core-languages/pom.xml
+++ b/core/camel-core-languages/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <camel.osgi.export>
-            org.apache.camel*;version=${camel-version}
+            org.apache.camel.language*;version=${camel-version}
         </camel.osgi.export>
         <camel.osgi.import>
             *
@@ -42,6 +42,28 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+            <version>${camel-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-languages</artifactId>
@@ -78,6 +100,12 @@
                                     <include>org.apache.camel:camel-core-languages</include>
                                 </includes>
                             </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/services/org/apache/camel/language/simple-no-file</resource>
+                                    <file>${project.basedir}/src/main/resources/META-INF/services/org/apache/camel/language/simple-no-file</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleNoFileLanguage.java
+++ b/core/camel-core-languages/src/main/java/org/apache/camel/language/simple/SimpleNoFileLanguage.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.language.simple;
+
+import org.apache.camel.spi.annotations.Language;
+
+/**
+ * The {@link SimpleLanguage} but without support for using the file based functions. This is used in some special
+ * situations with EIPs such as poll/pollEnrich. This language is not exposed as a public standard language and are only
+ * intended for internal use.
+ */
+@Language(value = "simple-no-file", functionsClass = SimpleConstants.class)
+public final class SimpleNoFileLanguage extends SimpleLanguage {
+
+    public SimpleNoFileLanguage() {
+        super(true);
+    }
+}

--- a/core/camel-core-languages/src/main/resources/META-INF/services/org/apache/camel/language/simple-no-file
+++ b/core/camel-core-languages/src/main/resources/META-INF/services/org/apache/camel/language/simple-no-file
@@ -1,0 +1,1 @@
+class=org.apache.camel.language.simple.SimpleNoFileLanguage


### PR DESCRIPTION
Backport of #708 to the `camel-karaf-4.18.x` branch.

Adds `simple-no-file` language support to `camel-core-languages`, fixing `NoSuchLanguageException: No language could be found for: simple-no-file` when resolving the language through `OsgiLanguageResolver` (issue #707).

Cherry-picked from 5aa2aed (authored by @robinvish2794); pom.xml auto-merged cleanly with no conflicts.

Refs #707. Original PR: #708.

---
_Claude Code on behalf of JB Onofré_
