### PR TITLE
fix(#710): add missing arns library bundle in camel-aws2-s3 feature (backport on camel-karaf-4.18.x branch)

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -622,6 +622,7 @@
         <feature version="${aws-java-sdk2-version}">awssdk</feature>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/s3/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-xml-protocol/${aws-java-sdk2-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/arns/${aws-java-sdk2-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-aws2-s3/${project.version}</bundle>
     </feature>
     <feature name='camel-aws2-s3-vectors' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Backport of #711 to `camel-karaf-4.18.x`.

Fixes #710

## Problem

The `camel-aws2-s3` feature throws `NoClassDefFoundError: software/amazon/awssdk/arns/Arn` when a route uses the object-copy path (e.g. `moveAfterRead` + `destinationBucket`):

```
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.arns.Arn not found by wrap_software.amazon.awssdk.s3
```

## Root cause

The feature wraps `software.amazon.awssdk/s3`, which uses `software.amazon.awssdk.arns.Arn` at runtime (`S3ArnUtils.getArnType` on the copy path). OSGi `wrap:` does not resolve transitive Maven dependencies, so the `arns` bundle must be declared explicitly in the feature.

## Fix

Add the missing `arns` bundle to the `camel-aws2-s3` feature, mirroring #711 on `main`.
