### PR TITLE
fix(#709): add missing org.springframework.http OSGi import in camel-cxf-all

### DIFF
--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -59,6 +59,7 @@
             org.springframework.beans*;resolution:=optional;version="${camel-osgi-spring-version}",
             org.springframework.context*;resolution:=optional;version="${camel-osgi-spring-version}",
             org.springframework.core*;resolution:=optional;version="${camel-osgi-spring-version}",
+            org.springframework.http*;resolution:=optional;version="${camel-osgi-spring-version}",
             org.springframework.util*;resolution:=optional;version="${camel-osgi-spring-version}",
             org.springframework.web*;resolution:=optional;version="${camel-osgi-spring-version}",
             org.objectweb.asm*;resolution:=optional;version="${camel-osgi-asm-version}",


### PR DESCRIPTION
## What

Adds the missing `org.springframework.http*` OSGi package import to the `camel-cxf-all` bundle.

Fixes #709.

## Why

With the CXF version bundled in 4.18, `org.apache.cxf.jaxrs.springmvc.SpringWebUtils` references `org.springframework.http.server.observation.ServerRequestObservationContext` (Spring 6 / Micrometer observability). At runtime this failed with:

```
java.lang.NoClassDefFoundError: org/springframework/http/server/observation/ServerRequestObservationContext
    at org.apache.cxf.jaxrs.springmvc.SpringWebUtils.setHttpRequestURI(SpringWebUtils.java:51)
    ...
Caused by: java.lang.ClassNotFoundException:
    org.springframework.http.server.observation.ServerRequestObservationContext
    cannot be found by camel-cxf-all_4.18.2
```

`camel-cxf-all` enumerates specific Spring sub-packages in `<camel.osgi.import>` (`aop`, `beans`, `context`, `core`, `util`, `web`) but did **not** import `org.springframework.http*`. That package is a sibling of `org.springframework.web`, so `org.springframework.web*` does not cover it — the package was never wired and the class could not be found.

Note `camel-cxf-spring-all` is unaffected because it imports the `org.springframework*` wildcard.

## Change

```xml
org.springframework.http*;resolution:=optional;version="${camel-osgi-spring-version}",
```

Marked `resolution:=optional` and versioned, consistent with the other optional Spring imports in this bundle (these Spring integrations are only used when Spring is on the classpath).

## Verification

Built the module and confirmed the generated `META-INF/MANIFEST.MF` now includes the required package:

```
org.springframework.http.server.observation;resolution:=optional;version="[6.2,...)"
```

## Scope

Karaf-specific packaging/OSGi-metadata delta only; no Camel-core change.