### PR TITLE
fix(#712): upgrade Apache CXF to 4.1.7 (CVE-2026-44417) [4.18.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,8 +166,8 @@
         <consul-client-version>1.9.2</consul-client-version>
         <couchbase-client-version>3.11.0</couchbase-client-version>
         <curator-version>5.9.0</curator-version>
-        <cxf-version>4.1.5</cxf-version>
-        <cxf-codegen-plugin-version>4.1.5</cxf-codegen-plugin-version>
+        <cxf-version>4.1.7</cxf-version>
+        <cxf-codegen-plugin-version>4.1.7</cxf-codegen-plugin-version>
         <cxf-xjc-plugin-version>4.1.2</cxf-xjc-plugin-version>
         <cxf-xjc-utils-version>4.1.2</cxf-xjc-utils-version>
         <daffodil-version>3.10.0</daffodil-version>


### PR DESCRIPTION
Backport of #717 to the `camel-karaf-4.18.x` branch.

## What

Upgrades the bundled **Apache CXF** from `4.1.5` to `4.1.7`.

Closes #712 for 4.18.x.

## Why

CXF `< 4.1.6` is affected by [CVE-2026-44417](https://nvd.nist.gov/vuln/detail/CVE-2026-44417) — an incomplete fix of CVE-2025-48913, allowing remote code execution when an untrusted party can influence the JMS configuration (CWE-20). It is fixed upstream in CXF **4.1.6 / 4.2.1 / 3.6.11**.

`4.1.7` is the latest `4.1.x` patch: it carries the CVE fix plus subsequent `4.1.x` fixes and stays within the existing OSGi import range `[4.1,4.2)`, so no other feature/import changes are required.

Per the camel-karaf security model, the vulnerability lives in **Apache CXF** (a packaged component); camel-karaf's role here is solely the bundled-version upgrade.

## Changes

- `pom.xml`: `cxf-version` `4.1.5` → `4.1.7`, and `cxf-codegen-plugin-version` moved in lockstep. The `cxf-xjc-*` plugins are a separately versioned artifact family and are left unchanged.

The `camel-cxf-all` bundle shades every `org.apache.cxf:*` artifact via `${cxf-version}`, so the rebuilt bundle embeds and re-exports CXF `4.1.7`.

## Notes

CVE-2026-44417 is already public and fixed upstream, and issue #712 is public — so this is a normal public dependency-bump backport (no embargo).