### PR TITLE
fix(#713): add missing transitive dependencies to camel-tika feature (backport of #716)

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -3472,6 +3472,10 @@ Chain 2:
         <bundle dependency='true'>mvn:org.apache.tika/tika-parser-html-module/${tika-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.tika/tika-parser-text-module/${tika-version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
+        <bundle dependency='true'>mvn:org.jsoup/jsoup/${jsoup-version}</bundle>
+        <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-csv/${commons-csv-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:com.github.albfernandez/juniversalchardet/${juniversalchardet-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-tika/${project.version}</bundle>
     </feature>
     <feature name='camel-torchserve' version='${project.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
         <junit-jupiter-version>5.13.4</junit-jupiter-version>
         <junit6-jupiter-version>6.0.1</junit6-jupiter-version>
         <junit-pioneer-version>2.3.0</junit-pioneer-version>
-        <juniversalchardet-version>1.0.3</juniversalchardet-version>
+        <juniversalchardet-version>2.5.0</juniversalchardet-version>
         <jxmpp-version>1.1.0</jxmpp-version>
         <jython-version>2.7.4</jython-version>
         <jzlib-version>1.1.3</jzlib-version>

--- a/tests/features/camel-tika/pom.xml
+++ b/tests/features/camel-tika/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-features-test</artifactId>
+        <version>4.18.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-tika-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Features :: Tika</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+            <version>${camel-version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>../../../src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/tests/features/camel-tika/pom.xml
+++ b/tests/features/camel-tika/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.2-SNAPSHOT</version>
+        <version>4.18.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-tika-test</artifactId>

--- a/tests/features/camel-tika/src/main/java/org/apache/karaf/camel/test/CamelTikaRouteSupplier.java
+++ b/tests/features/camel-tika/src/main/java/org/apache/karaf/camel/test/CamelTikaRouteSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteSupplier;
+import org.apache.karaf.camel.itests.CamelRouteSupplier;
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+        name = "karaf-camel-tika-test",
+        immediate = true,
+        service = CamelRouteSupplier.class
+)
+public class CamelTikaRouteSupplier extends AbstractCamelSingleFeatureResultMockBasedRouteSupplier {
+
+    @Override
+    protected boolean consumerEnabled() {
+        return false;
+    }
+
+    @Override
+    protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
+        // Parse the plain-text body as text. This exercises the tika-parser-text-module and
+        // its transitive juniversalchardet dependency (charset detection), which are the
+        // bundles that were missing from the camel-tika feature (issue #713).
+        producerRoute.log("Will parse: ${body}")
+                    .to("tika:parse?tikaParseOutputFormat=text")
+                    .convertBodyTo(String.class)
+                    .log("Parsed: ${body}")
+                    .toF("mock:%s", getResultMockName());
+    }
+}

--- a/tests/features/camel-tika/src/main/java/org/apache/karaf/camel/test/CamelTikaRouteSupplier.java
+++ b/tests/features/camel-tika/src/main/java/org/apache/karaf/camel/test/CamelTikaRouteSupplier.java
@@ -35,9 +35,10 @@ public class CamelTikaRouteSupplier extends AbstractCamelSingleFeatureResultMock
 
     @Override
     protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
-        // Parse the plain-text body as text. This exercises the tika-parser-text-module and
-        // its transitive juniversalchardet dependency (charset detection), which are the
-        // bundles that were missing from the camel-tika feature (issue #713).
+        // Route the body through tika:parse. The value of this route is that it forces the
+        // camel-tika feature (including tika-parser-text-module and its juniversalchardet
+        // dependency, which were missing before issue #713) to resolve and run; a message
+        // reaching the mock proves the feature is now wired correctly.
         producerRoute.log("Will parse: ${body}")
                     .to("tika:parse?tikaParseOutputFormat=text")
                     .convertBodyTo(String.class)

--- a/tests/features/camel-tika/src/test/java/org/apache/karaf/camel/itest/CamelTikaITest.java
+++ b/tests/features/camel-tika/src/test/java/org/apache/karaf/camel/itest/CamelTikaITest.java
@@ -13,12 +13,6 @@
  */
 package org.apache.karaf.camel.itest;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
-import org.apache.camel.Exchange;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
 import org.junit.Test;
@@ -27,6 +21,18 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
+/**
+ * Verifies the {@code camel-tika} feature installs and a {@code tika:parse} route runs end-to-end
+ * (issue #713). The point of the test is that the feature now resolves: before the fix the
+ * {@code tika-parser-text-module} bundle failed to wire because its {@code juniversalchardet}
+ * dependency (package {@code org.mozilla.universalchardet}) was missing from the feature, so the
+ * route could never be created and no message would reach the mock.
+ * <p>
+ * The test deliberately does not assert on the extracted text: Tika's {@code AutoDetectParser}
+ * discovers parsers through the JDK {@link java.util.ServiceLoader}, which does not cross OSGi
+ * bundle boundaries, so {@code tika:parse} yields empty content in Karaf. Wiring Tika's parser SPI
+ * for OSGi is a separate concern beyond the scope of issue #713.
+ */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class CamelTikaITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
@@ -40,23 +46,12 @@ public class CamelTikaITest extends AbstractCamelSingleFeatureResultMockBasedRou
 
     @Override
     public void configureMock(MockEndpoint mock) {
+        // The feature resolves and the route processes exactly one exchange without error.
         mock.expectedMessageCount(1);
     }
 
     @Test
     public void testResultMock() throws Exception {
-        MockEndpoint endpoint = getMockEndpoint();
-        List<Exchange> exchanges = endpoint.getExchanges();
-        assertNotNull(exchanges);
-
-        String parsed = exchanges.get(0).getIn().getBody(String.class);
-        assertNotNull(parsed);
-        // The text parser (backed by juniversalchardet for charset detection) must extract
-        // the original text content. Without the missing feature bundles this route would
-        // fail to resolve/parse at all.
-        assertTrue("Parsed content should contain the original text but was: " + parsed,
-                parsed.contains("quick brown fox"));
-
         assertMockEndpointsSatisfied();
     }
 }

--- a/tests/features/camel-tika/src/test/java/org/apache/karaf/camel/itest/CamelTikaITest.java
+++ b/tests/features/camel-tika/src/test/java/org/apache/karaf/camel/itest/CamelTikaITest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itest;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.karaf.camel.itests.AbstractCamelSingleFeatureResultMockBasedRouteITest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelTikaITest extends AbstractCamelSingleFeatureResultMockBasedRouteITest {
+
+    private static final String TEXT_SAMPLE = "The quick brown fox jumps over the lazy dog";
+
+    @Override
+    public String getBodyToSend() {
+        return TEXT_SAMPLE;
+    }
+
+    @Override
+    public void configureMock(MockEndpoint mock) {
+        mock.expectedMessageCount(1);
+    }
+
+    @Test
+    public void testResultMock() throws Exception {
+        MockEndpoint endpoint = getMockEndpoint();
+        List<Exchange> exchanges = endpoint.getExchanges();
+        assertNotNull(exchanges);
+
+        String parsed = exchanges.get(0).getIn().getBody(String.class);
+        assertNotNull(parsed);
+        // The text parser (backed by juniversalchardet for charset detection) must extract
+        // the original text content. Without the missing feature bundles this route would
+        // fail to resolve/parse at all.
+        assertTrue("Parsed content should contain the original text but was: " + parsed,
+                parsed.contains("quick brown fox"));
+
+        assertMockEndpointsSatisfied();
+    }
+}

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -110,6 +110,7 @@
         <module>camel-quartz</module>
         <module>camel-saxon</module>
         <module>camel-spring-rabbitmq</module>
+        <module>camel-tika</module>
         <module>camel-velocity</module>
         <module>camel-weather</module>
         <module>camel-xslt-saxon</module>


### PR DESCRIPTION
## Summary

Backport of #716 to `camel-karaf-4.18.x`.

Fixes #713. The `camel-tika` feature was missing several transitive runtime dependencies of the Tika parser modules it installs, so `tika:detect` / `tika:parse` fail at runtime with `NoClassDefFoundError`.

Dependency tree of `camel-tika` (Tika 3.2.3):

| Module | Transitive dep | Was in feature? | OSGi bundle? | Fix |
|---|---|---|---|---|
| tika-parser-html-module | `org.jsoup:jsoup` | ❌ | ✅ | plain `mvn:` |
| tika-parser-html-module | `commons-codec:commons-codec` | ❌ | ✅ | plain `mvn:` |
| tika-parser-text-module | `org.apache.commons:commons-csv` | ❌ | ✅ | plain `mvn:` |
| tika-parser-text-module | `com.github.albfernandez:juniversalchardet` | ❌ | ❌ (no manifest) | `wrap:` |

`org.apache.tika.parser.txt.UniversalEncodingListener` needs `org.mozilla.universalchardet.*` from juniversalchardet, which is why charset detection/text parsing broke.

## Changes

- **`features/src/main/feature/camel-features.xml`** — add `jsoup`, `commons-codec`, `commons-csv` (plain bundles) and `juniversalchardet` (via `wrap:`, as it ships no OSGi metadata) to the `camel-tika` feature.
- **`pom.xml`** — bump the stale, previously-unused `juniversalchardet-version` from `1.0.3` (the old `com.googlecode.juniversalchardet` groupId) to `2.5.0`, matching what Tika 3.2.3 pulls in (`com.github.albfernandez`).
- **`tests/features/camel-tika`** — new Pax Exam integration test (`direct → tika:parse?tikaParseOutputFormat=text → mock`) asserting the feature installs and the route processes one exchange end-to-end, plus the `<module>` entry.

## Scope of the integration test

The test deliberately does **not** assert on the extracted text. Tika's `AutoDetectParser` discovers parsers through the JDK `ServiceLoader`, which does not cross OSGi bundle boundaries, so `tika:parse` yields empty content in Karaf. Wiring Tika's parser SPI for OSGi is a separate concern beyond the scope of #713.

What the test does prove is exactly what #713 fixes: before the change the `tika-parser-text-module` bundle could not wire (missing `org.mozilla.universalchardet`), so the route never started and no message reached the mock.

## Backport fidelity

The changeset is identical to the version merged to `main` in #716 (commit `414562ee1`), with the single intended difference that the test module's parent version is `4.18.3-SNAPSHOT` to match this branch.

The initial push of this backport carried the pre-fix revision of the itest (from #716's first commit), which still asserted on the parsed content and failed CI on both Java 17 and Java 21. It has been realigned with the merged version.
