### PR TITLE
fix(#729): escape names embedded in OSGi service filters

### DIFF
--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -74,6 +74,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-version}</version>

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiBeanRepository.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiBeanRepository.java
@@ -27,6 +27,7 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.Service;
 import org.apache.camel.spi.BeanRepository;
 import org.apache.camel.support.LifecycleStrategySupport;
+import org.apache.camel.karaf.core.utils.OsgiFilterHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
@@ -57,7 +58,7 @@ public class OsgiBeanRepository extends LifecycleStrategySupport implements Bean
         Object service = null;
         ServiceReference<?> sr;
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(type.getName(), "(name=" + name + ")");
+            ServiceReference<?>[] refs = bundleContext.getServiceReferences(type.getName(), OsgiFilterHelper.createFilter("name", name));
             if (refs != null && refs.length > 0) {
                 // just return the first one
                 sr = refs[0];
@@ -80,7 +81,7 @@ public class OsgiBeanRepository extends LifecycleStrategySupport implements Bean
         ServiceReference<?> sr = bundleContext.getServiceReference(name);
         if (sr == null) {
             // trying to lookup service by PID if not found by name
-            String filterExpression = "(" + Constants.SERVICE_PID + "=" + name + ")";
+            String filterExpression = OsgiFilterHelper.createFilter(Constants.SERVICE_PID, name);
             try {
                 ServiceReference<?>[] refs = bundleContext.getServiceReferences((String)null, filterExpression);
                 if (refs != null && refs.length > 0) {

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiComponentResolver.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiComponentResolver.java
@@ -21,6 +21,7 @@ import org.apache.camel.Component;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.ComponentResolver;
 import org.apache.camel.support.ResolverHelper;
+import org.apache.camel.karaf.core.utils.OsgiFilterHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -50,7 +51,7 @@ public class OsgiComponentResolver implements ComponentResolver {
     protected Component getComponent(String name, CamelContext context) throws Exception {
         LOG.trace("Finding Component: {}", name);
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(ComponentResolver.class.getName(), "(component=" + name + ")");
+            ServiceReference<?>[] refs = bundleContext.getServiceReferences(ComponentResolver.class.getName(), OsgiFilterHelper.createFilter("component", name));
             if (refs != null) {
                 for (ServiceReference<?> ref : refs) {
                     Object service = bundleContext.getService(ref);

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiDataFormatResolver.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiDataFormatResolver.java
@@ -24,6 +24,7 @@ import org.apache.camel.spi.DataFormat;
 import org.apache.camel.spi.DataFormatFactory;
 import org.apache.camel.spi.DataFormatResolver;
 import org.apache.camel.support.ResolverHelper;
+import org.apache.camel.karaf.core.utils.OsgiFilterHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -59,7 +60,7 @@ public class OsgiDataFormatResolver implements DataFormatResolver {
     private DataFormat getDataFormat(String name, CamelContext context) {
         LOG.trace("Finding DataFormat: {}", name);
         try {
-            Collection<ServiceReference<DataFormatResolver>> refs = bundleContext.getServiceReferences(DataFormatResolver.class, "(dataformat=" + name + ")");
+            Collection<ServiceReference<DataFormatResolver>> refs = bundleContext.getServiceReferences(DataFormatResolver.class, OsgiFilterHelper.createFilter("dataformat", name));
             if (refs != null) {
                 for (ServiceReference<DataFormatResolver> ref : refs) {
                     return bundleContext.getService(ref).createDataFormat(name, context);

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiLanguageResolver.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/OsgiLanguageResolver.java
@@ -22,6 +22,7 @@ import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.LanguageResolver;
 import org.apache.camel.support.ResolverHelper;
+import org.apache.camel.karaf.core.utils.OsgiFilterHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -59,7 +60,7 @@ public class OsgiLanguageResolver implements LanguageResolver {
     protected Language getLanguage(String name, CamelContext context) {
         LOG.trace("Finding Language: {}", name);
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(LanguageResolver.class.getName(), "(language=" + name + ")");
+            ServiceReference<?>[] refs = bundleContext.getServiceReferences(LanguageResolver.class.getName(), OsgiFilterHelper.createFilter("language", name));
             if (refs != null) {
                 for (ServiceReference<?> ref : refs) {
                     Object service = bundleContext.getService(ref);
@@ -79,7 +80,7 @@ public class OsgiLanguageResolver implements LanguageResolver {
     protected LanguageResolver getLanguageResolver(String name, CamelContext context) {
         LOG.trace("Finding LanguageResolver: {}", name);
         try {
-            ServiceReference<?>[] refs = bundleContext.getServiceReferences(LanguageResolver.class.getName(), "(resolver=" + name + ")");
+            ServiceReference<?>[] refs = bundleContext.getServiceReferences(LanguageResolver.class.getName(), OsgiFilterHelper.createFilter("resolver", name));
             if (refs != null) {
                 for (ServiceReference<?> ref : refs) {
                     Object service = bundleContext.getService(ref);

--- a/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/utils/OsgiFilterHelper.java
+++ b/core/camel-core-osgi/src/main/java/org/apache/camel/karaf/core/utils/OsgiFilterHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.karaf.core.utils;
+
+/**
+ * Helper to build OSGi service filters from values that are not known to be filter safe.
+ */
+public final class OsgiFilterHelper {
+
+    private OsgiFilterHelper() {
+    }
+
+    /**
+     * Builds the filter <tt>(key=value)</tt>, escaping the value so it is matched literally.
+     *
+     * @param  key   the attribute to match on, must be a literal known to the caller
+     * @param  value the value to match, escaped before being embedded
+     * @return       the filter expression
+     */
+    public static String createFilter(String key, String value) {
+        return "(" + key + "=" + escapeFilterValue(value) + ")";
+    }
+
+    /**
+     * Escapes the characters that are significant in an OSGi filter value.
+     * <p/>
+     * The OSGi core specification defines its own filter grammar, in which a value escapes <tt>(</tt>, <tt>)</tt>,
+     * <tt>*</tt> and <tt>\</tt> by prefixing a single backslash. Note this is not the <tt>\2a</tt> hex form used by
+     * the LDAP string representation in RFC 4515: an OSGi {@code Filter} would read that as the two literal
+     * characters <tt>2a</tt>.
+     * <p/>
+     * Without escaping, a name is parsed as filter syntax rather than matched as text, so <tt>*</tt> becomes a
+     * presence assertion matching every registered service, and an unbalanced parenthesis makes the framework reject
+     * the filter instead of simply not matching.
+     *
+     * @param  value the value to escape, may be <tt>null</tt>
+     * @return       the escaped value, or <tt>null</tt> if the given value was <tt>null</tt>
+     */
+    public static String escapeFilterValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        int first = indexOfSignificantCharacter(value);
+        if (first == -1) {
+            // legitimate component, language, dataformat and bean names never need escaping
+            return value;
+        }
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        sb.append(value, 0, first);
+        for (int i = first; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '*', '(', ')', '\\' -> sb.append('\\').append(ch);
+                default -> sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static int indexOfSignificantCharacter(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            switch (value.charAt(i)) {
+                case '*', '(', ')', '\\' -> {
+                    return i;
+                }
+                default -> {
+                    // keep looking
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/core/camel-core-osgi/src/test/java/org/apache/camel/karaf/core/utils/OsgiFilterHelperTest.java
+++ b/core/camel-core-osgi/src/test/java/org/apache/camel/karaf/core/utils/OsgiFilterHelperTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.karaf.core.utils;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OsgiFilterHelperTest {
+
+    @Test
+    public void testNullValue() {
+        assertNull(OsgiFilterHelper.escapeFilterValue(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jms", "http", "aws2-s3", "camel-bean", "xpath", "org.apache.camel.MyBean", "a+b"})
+    public void testLegitimateNamesAreUnchanged(String name) {
+        assertEquals(name, OsgiFilterHelper.escapeFilterValue(name));
+        assertEquals("(component=" + name + ")", OsgiFilterHelper.createFilter("component", name));
+    }
+
+    @Test
+    public void testSignificantCharactersAreEscaped() {
+        // the OSGi filter grammar escapes with a backslash before the character, not with the
+        // RFC 4515 hex form - an OSGi Filter reads "\\2a" as the two literal characters 2a
+        assertEquals("\\*", OsgiFilterHelper.escapeFilterValue("*"));
+        assertEquals("\\(", OsgiFilterHelper.escapeFilterValue("("));
+        assertEquals("\\)", OsgiFilterHelper.escapeFilterValue(")"));
+        assertEquals("\\\\", OsgiFilterHelper.escapeFilterValue("\\"));
+        assertEquals("a\\*b", OsgiFilterHelper.escapeFilterValue("a*b"));
+    }
+
+    /**
+     * The point of the escaping: a wildcard name must stop selecting every registered service.
+     */
+    @Test
+    public void testWildcardNoLongerMatchesAnArbitraryService() throws InvalidSyntaxException {
+        Filter filter = FrameworkUtil.createFilter(OsgiFilterHelper.createFilter("name", "*"));
+        assertFalse(filter.match(properties("name", "someRegisteredBean")),
+                "an escaped * must not match an unrelated service");
+        assertFalse(filter.match(properties("name", "anotherBean")),
+                "an escaped * must not match an unrelated service");
+        assertTrue(filter.match(properties("name", "*")),
+                "it must still match a service whose name really is *");
+    }
+
+    @Test
+    public void testUnescapedWildcardWouldHaveMatched() throws InvalidSyntaxException {
+        // documents the behaviour being fixed
+        Filter unescaped = FrameworkUtil.createFilter("(name=*)");
+        assertTrue(unescaped.match(properties("name", "someRegisteredBean")));
+    }
+
+    @Test
+    public void testInjectedFilterSyntaxIsNeutralised() throws InvalidSyntaxException {
+        String hostile = "x)(objectClass=org.apache.karaf.features.FeaturesService";
+        Filter filter = assertDoesNotThrow(() -> FrameworkUtil.createFilter(OsgiFilterHelper.createFilter("name", hostile)),
+                "an escaped name must produce a valid filter rather than a syntax error");
+        assertFalse(filter.match(properties("name", "someRegisteredBean")));
+        assertFalse(filter.match(properties("objectClass", "org.apache.karaf.features.FeaturesService")));
+        assertTrue(filter.match(properties("name", hostile)));
+    }
+
+    @Test
+    public void testUnbalancedParenthesisNoLongerFaultsTheFilter() {
+        assertDoesNotThrow(() -> FrameworkUtil.createFilter(OsgiFilterHelper.createFilter("component", ")(")),
+                "an unbalanced parenthesis must not make the framework reject the filter");
+    }
+
+    private static Dictionary<String, Object> properties(String key, Object value) {
+        Dictionary<String, Object> d = new Hashtable<>();
+        d.put(key, value);
+        return d;
+    }
+}


### PR DESCRIPTION
Fixes #729

## What

Six lookups in `camel-core-osgi` built an OSGi service filter by concatenating a
name straight into it:

| file | filter |
|---|---|
| `OsgiBeanRepository:60` | `(name=<name>)` |
| `OsgiBeanRepository:83` | `(service.pid=<name>)` |
| `OsgiComponentResolver:53` | `(component=<name>)` |
| `OsgiLanguageResolver:62` | `(language=<name>)` |
| `OsgiLanguageResolver:82` | `(resolver=<name>)` |
| `OsgiDataFormatResolver:62` | `(dataformat=<name>)` |

Filter metacharacters in the name were read as filter syntax rather than matched
as text. A name of `*` becomes a presence assertion matching every registered
service, and since each site takes `refs[0]`, the lookup returned an arbitrary
service instead of not resolving. A name containing `)(` made the framework
reject the filter, faulting the exchange with a syntax error rather than giving
a clean not-found.

## How

All six go through `OsgiFilterHelper.createFilter(key, value)`, which escapes
the value before embedding it.

**Escaping only.** The FQCN and `service.pid` interpretations in `lookupByName`
are the documented purpose of `OsgiBeanRepository` and are left intact —
narrowing them would be a behaviour change for existing deployments, and is a
separate discussion. `getServiceReference(name)` at `OsgiBeanRepository:80`
takes an exact interface name rather than a filter, so it needs nothing.

For every legitimate name (`jms`, `aws2-s3`, `org.apache.camel.MyBean`, …) the
helper returns the string unchanged, so there is no behaviour change on the
normal path.

## A correction worth flagging

#729 suggested RFC 4515 escaping. **That is the wrong grammar for OSGi** and I
had written it that way first — the tests caught it.

The OSGi Core specification defines its own filter grammar in which a value
escapes `(`, `)`, `*` and `\` with a **single preceding backslash**. The RFC 4515
hex form `\2a` is read by an OSGi `Filter` as the two literal characters `2a`,
so escaping `*` as `\2a` would have stopped a wildcard matching everything but
would also have stopped it matching a service genuinely named `*` — silently
wrong rather than safe. The helper now emits `\*`, `\(`, `\)`, `\\` and the
javadoc says why.

## Tests

`OsgiFilterHelperTest` (13 cases). The important ones do not assert on the
rewritten string — they build a **real** `Filter` via `FrameworkUtil.createFilter`
and check what it actually matches:

- `(name=*)` escaped no longer matches `name=someRegisteredBean`, but still
  matches a service whose name really is `*`
- a name of `x)(objectClass=org.apache.karaf.features.FeaturesService` produces
  a valid filter that matches neither an unrelated `name` nor the injected
  `objectClass` clause, and matches only the literal name
- `)(` no longer makes `createFilter` throw
- one test pins the pre-fix behaviour (`(name=*)` unescaped *does* match an
  arbitrary service) so the regression is visible if the escaping is ever lost

```
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

(25 = 13 new + the 12 pre-existing `camel-core-osgi` tests, all still passing.)

Also adds the `junit-jupiter-params` test dependency.

---
_Claude Code on behalf of Andrea Cosentino_