### PR TITLE
fix(#732): hide the CXF service list page by default

### DIFF
--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -366,6 +366,32 @@
             <artifactId>jakarta.xml.ws-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/camel-cxf/camel-cxf-all/src/main/java/org/apache/camel/component/cxf/transport/http/osgi/ServletExporter.java
+++ b/components/camel-cxf/camel-cxf-all/src/main/java/org/apache/camel/component/cxf/transport/http/osgi/ServletExporter.java
@@ -73,8 +73,12 @@ class ServletExporter implements ManagedService {
                 Boolean.valueOf(getProp(properties, CXF_SERVLET_PREFIX + "async-supported", "true").toString()));
 
         // Pass CXF servlet init parameters
+        // the service list page enumerates every CXF endpoint in the container and is served
+        // unauthenticated, so it is opt in rather than on by default; set
+        // org.apache.cxf.servlet.hide-service-list-page=false in the org.apache.cxf.osgi PID to
+        // get it back, optionally with service-list-page-authenticate=true
         whiteboardProps.put("servlet.init.hide-service-list-page",
-                getProp(properties, CXF_SERVLET_PREFIX + "hide-service-list-page", "false"));
+                getProp(properties, CXF_SERVLET_PREFIX + "hide-service-list-page", "true"));
         whiteboardProps.put("servlet.init.disable-address-updates",
                 getProp(properties, CXF_SERVLET_PREFIX + "disable-address-updates", "true"));
         whiteboardProps.put("servlet.init.base-address",

--- a/components/camel-cxf/camel-cxf-all/src/test/java/org/apache/camel/component/cxf/transport/http/osgi/ServletExporterTest.java
+++ b/components/camel-cxf/camel-cxf-all/src/test/java/org/apache/camel/component/cxf/transport/http/osgi/ServletExporterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.cxf.transport.http.osgi;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import jakarta.servlet.Servlet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ServletExporterTest {
+
+    @Mock
+    private Servlet servlet;
+    @Mock
+    private BundleContext bundleContext;
+    @Mock
+    private ServiceRegistration<Servlet> registration;
+
+    @SuppressWarnings("unchecked")
+    private Dictionary<String, Object> register(Dictionary<String, Object> config) throws Exception {
+        lenient().when(bundleContext.registerService(eq(Servlet.class), any(Servlet.class), any()))
+                .thenReturn(registration);
+
+        new ServletExporter(servlet, bundleContext).updated(config);
+
+        ArgumentCaptor<Dictionary<String, Object>> captor = ArgumentCaptor.forClass(Dictionary.class);
+        verify(bundleContext).registerService(eq(Servlet.class), eq(servlet), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testServiceListPageIsHiddenByDefault() throws Exception {
+        assertEquals("true", register(new Hashtable<>()).get("servlet.init.hide-service-list-page"),
+                "the endpoint listing must be opt in");
+    }
+
+    @Test
+    public void testServiceListPageIsHiddenWhenThereIsNoConfigurationAtAll() throws Exception {
+        // ConfigAdmin calls updated(null) when no org.apache.cxf.osgi configuration exists,
+        // which is the shape a default install actually takes
+        assertEquals("true", register(null).get("servlet.init.hide-service-list-page"),
+                "the null config path must use the same default");
+    }
+
+    @Test
+    public void testServiceListPageCanStillBeTurnedBackOn() throws Exception {
+        Dictionary<String, Object> config = new Hashtable<>();
+        config.put("org.apache.cxf.servlet.hide-service-list-page", "false");
+        assertEquals("false", register(config).get("servlet.init.hide-service-list-page"),
+                "an explicit opt in must still be honoured");
+    }
+
+    @Test
+    public void testOtherDefaultsAreUnchanged() throws Exception {
+        Dictionary<String, Object> props = register(new Hashtable<>());
+        assertEquals("true", props.get("servlet.init.disable-address-updates"));
+        assertEquals("karaf", props.get("servlet.init.service-list-page-authenticate-realm"));
+        assertEquals("false", props.get("servlet.init.use-x-forwarded-headers"));
+        assertEquals("/cxf/*", props.get("osgi.http.whiteboard.servlet.pattern"));
+    }
+}


### PR DESCRIPTION
Fixes #732

## What

`ServletExporter` registered the CXF transport servlet with:

```java
whiteboardProps.put("servlet.init.hide-service-list-page",
        getProp(properties, CXF_SERVLET_PREFIX + "hide-service-list-page", "false"));   // :76-77
...
whiteboardProps.put("servlet.init.service-list-page-authenticate",
        getProp(properties, CXF_SERVLET_PREFIX + "service-list-page-authenticate", "false"));   // :94-95
```

`HTTPTransportActivator` registers the `ManagedService`, so with no
`org.apache.cxf.osgi` configuration these defaults apply as-is — including on the
`updated(null)` path (`:61-63`), which is the shape a default install actually
takes. Installing the feature therefore published an enumerable, unauthenticated
listing of every CXF endpoint in the container at `/cxf`, with no configuration
step needed to turn it on.

## How

`hide-service-list-page` now defaults to `"true"`, making the listing opt-in.

I left `service-list-page-authenticate` alone: once the page is hidden by
default, turning it on is a deliberate act, and the authentication realm already
defaults to `karaf` for an operator who wants both. Flipping two defaults at
once would make the opt-in path harder to reason about.

An operator who wants the page back sets, in the `org.apache.cxf.osgi` PID:

```
org.apache.cxf.servlet.hide-service-list-page=false
org.apache.cxf.servlet.service-list-page-authenticate=true   # optional
```

which is recorded in a comment at the call site.

## Tests

`ServletExporterTest` captures the whiteboard properties handed to
`registerService` and asserts:

- the default is `"true"` for an empty config
- **and on the `updated(null)` path** — that is the one a default install
  exercises, and it was a separate code path
- an explicit `hide-service-list-page=false` is still honoured, so the opt-in
  works
- the surrounding defaults (`disable-address-updates`,
  `service-list-page-authenticate-realm`, `use-x-forwarded-headers`, the servlet
  pattern) are unchanged

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The module had no test sources, so this adds the `junit-jupiter` and `mockito`
test dependencies.

## Notes

- These values match historic upstream CXF defaults. CXF 4.x ships no OSGi
  transport module, so this glue is maintained here now and the default is ours
  to choose.
- Each endpoint's `?wsdl` is reachable without authentication regardless, so this
  removes a discovery convenience rather than closing a disclosure channel —
  which is why it is a default change rather than a fix to the servlet itself.
- **This is visible behaviour for anyone relying on the page and wants a release
  note.** #732 also asked for the PID to be documented in the camel-cxf feature
  docs; `docs/modules/ROOT/pages/components.adoc` is currently just a pointer to
  `camel-features.xml` with no per-component pages, so there is no natural place
  for it yet — the call-site comment carries it yet.

---
_Claude Code on behalf of Andrea Cosentino_