### PR TITLE
Upgrade to Camel 4.18.4

### DIFF
--- a/components/camel-activemq/pom.xml
+++ b/components/camel-activemq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-activemq6/pom.xml
+++ b/components/camel-activemq6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-chatscript/pom.xml
+++ b/components/camel-ai/camel-chatscript/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-djl/pom.xml
+++ b/components/camel-ai/camel-djl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-docling/pom.xml
+++ b/components/camel-ai/camel-docling/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-kserve/pom.xml
+++ b/components/camel-ai/camel-kserve/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-agent/pom.xml
+++ b/components/camel-ai/camel-langchain4j-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-chat/pom.xml
+++ b/components/camel-ai/camel-langchain4j-chat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-core/pom.xml
+++ b/components/camel-ai/camel-langchain4j-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-embeddings/pom.xml
+++ b/components/camel-ai/camel-langchain4j-embeddings/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-embeddingstore/pom.xml
+++ b/components/camel-ai/camel-langchain4j-embeddingstore/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-tokenizer/pom.xml
+++ b/components/camel-ai/camel-langchain4j-tokenizer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-tools/pom.xml
+++ b/components/camel-ai/camel-langchain4j-tools/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-langchain4j-web-search/pom.xml
+++ b/components/camel-ai/camel-langchain4j-web-search/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-milvus/pom.xml
+++ b/components/camel-ai/camel-milvus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-neo4j/pom.xml
+++ b/components/camel-ai/camel-neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-openai/pom.xml
+++ b/components/camel-ai/camel-openai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-pinecone/pom.xml
+++ b/components/camel-ai/camel-pinecone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-qdrant/pom.xml
+++ b/components/camel-ai/camel-qdrant/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-tensorflow-serving/pom.xml
+++ b/components/camel-ai/camel-tensorflow-serving/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-torchserve/pom.xml
+++ b/components/camel-ai/camel-torchserve/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/camel-weaviate/pom.xml
+++ b/components/camel-ai/camel-weaviate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ai-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ai/pom.xml
+++ b/components/camel-ai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-amqp/pom.xml
+++ b/components/camel-amqp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-arangodb/pom.xml
+++ b/components/camel-arangodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-as2/pom.xml
+++ b/components/camel-as2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-asn1/pom.xml
+++ b/components/camel-asn1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-asterisk/pom.xml
+++ b/components/camel-asterisk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-atmosphere-websocket/pom.xml
+++ b/components/camel-atmosphere-websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-atom/pom.xml
+++ b/components/camel-atom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-attachments/pom.xml
+++ b/components/camel-attachments/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-avro-rpc-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/camel-avro-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-avro-rpc-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro-rpc/pom.xml
+++ b/components/camel-avro-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-avro/pom.xml
+++ b/components/camel-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-bedrock/pom.xml
+++ b/components/camel-aws/camel-aws-bedrock/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-cloudtrail/pom.xml
+++ b/components/camel-aws/camel-aws-cloudtrail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-common/pom.xml
+++ b/components/camel-aws/camel-aws-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-config/pom.xml
+++ b/components/camel-aws/camel-aws-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-parameter-store/pom.xml
+++ b/components/camel-aws/camel-aws-parameter-store/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-secrets-manager/pom.xml
+++ b/components/camel-aws/camel-aws-secrets-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-security-hub/pom.xml
+++ b/components/camel-aws/camel-aws-security-hub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws-xray/pom.xml
+++ b/components/camel-aws/camel-aws-xray/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-athena/pom.xml
+++ b/components/camel-aws/camel-aws2-athena/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-comprehend/pom.xml
+++ b/components/camel-aws/camel-aws2-comprehend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-cw/pom.xml
+++ b/components/camel-aws/camel-aws2-cw/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ddb/pom.xml
+++ b/components/camel-aws/camel-aws2-ddb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ec2/pom.xml
+++ b/components/camel-aws/camel-aws2-ec2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ecs/pom.xml
+++ b/components/camel-aws/camel-aws2-ecs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-eks/pom.xml
+++ b/components/camel-aws/camel-aws2-eks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-eventbridge/pom.xml
+++ b/components/camel-aws/camel-aws2-eventbridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-iam/pom.xml
+++ b/components/camel-aws/camel-aws2-iam/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-kinesis/pom.xml
+++ b/components/camel-aws/camel-aws2-kinesis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-kms/pom.xml
+++ b/components/camel-aws/camel-aws2-kms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-lambda/pom.xml
+++ b/components/camel-aws/camel-aws2-lambda/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-mq/pom.xml
+++ b/components/camel-aws/camel-aws2-mq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-msk/pom.xml
+++ b/components/camel-aws/camel-aws2-msk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-polly/pom.xml
+++ b/components/camel-aws/camel-aws2-polly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-redshift/pom.xml
+++ b/components/camel-aws/camel-aws2-redshift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-rekognition/pom.xml
+++ b/components/camel-aws/camel-aws2-rekognition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-s3-vectors/pom.xml
+++ b/components/camel-aws/camel-aws2-s3-vectors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-s3/pom.xml
+++ b/components/camel-aws/camel-aws2-s3/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-ses/pom.xml
+++ b/components/camel-aws/camel-aws2-ses/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sns/pom.xml
+++ b/components/camel-aws/camel-aws2-sns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sqs/pom.xml
+++ b/components/camel-aws/camel-aws2-sqs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-step-functions/pom.xml
+++ b/components/camel-aws/camel-aws2-step-functions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-sts/pom.xml
+++ b/components/camel-aws/camel-aws2-sts/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-textract/pom.xml
+++ b/components/camel-aws/camel-aws2-textract/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-timestream/pom.xml
+++ b/components/camel-aws/camel-aws2-timestream/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-transcribe/pom.xml
+++ b/components/camel-aws/camel-aws2-transcribe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/camel-aws2-translate/pom.xml
+++ b/components/camel-aws/camel-aws2-translate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-aws/pom.xml
+++ b/components/camel-aws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-cosmosdb/pom.xml
+++ b/components/camel-azure/camel-azure-cosmosdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-eventgrid/pom.xml
+++ b/components/camel-azure/camel-azure-eventgrid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-eventhubs/pom.xml
+++ b/components/camel-azure/camel-azure-eventhubs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-files/pom.xml
+++ b/components/camel-azure/camel-azure-files/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-key-vault/pom.xml
+++ b/components/camel-azure/camel-azure-key-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-schema-registry/pom.xml
+++ b/components/camel-azure/camel-azure-schema-registry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-servicebus/pom.xml
+++ b/components/camel-azure/camel-azure-servicebus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-blob/pom.xml
+++ b/components/camel-azure/camel-azure-storage-blob/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-datalake/pom.xml
+++ b/components/camel-azure/camel-azure-storage-datalake/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/camel-azure-storage-queue/pom.xml
+++ b/components/camel-azure/camel-azure-storage-queue/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-azure/pom.xml
+++ b/components/camel-azure/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-barcode/pom.xml
+++ b/components/camel-barcode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-base64/pom.xml
+++ b/components/camel-base64/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bean-validator/pom.xml
+++ b/components/camel-bean-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bean/pom.xml
+++ b/components/camel-bean/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-beanio/pom.xml
+++ b/components/camel-beanio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bindy/pom.xml
+++ b/components/camel-bindy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-blueprint/pom.xml
+++ b/components/camel-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-bonita/pom.xml
+++ b/components/camel-bonita/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-box/pom.xml
+++ b/components/camel-box/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-braintree/pom.xml
+++ b/components/camel-braintree/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-browse/pom.xml
+++ b/components/camel-browse/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-caffeine/pom.xml
+++ b/components/camel-caffeine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cbor/pom.xml
+++ b/components/camel-cbor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-chunk/pom.xml
+++ b/components/camel-chunk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-clickup/pom.xml
+++ b/components/camel-clickup/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cloudevents/pom.xml
+++ b/components/camel-cloudevents/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cm-sms/pom.xml
+++ b/components/camel-cm-sms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cometd/pom.xml
+++ b/components/camel-cometd/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-consul/pom.xml
+++ b/components/camel-consul/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-controlbus/pom.xml
+++ b/components/camel-controlbus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-couchbase/pom.xml
+++ b/components/camel-couchbase/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-couchdb/pom.xml
+++ b/components/camel-couchdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cron/pom.xml
+++ b/components/camel-cron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-crypto-pgp/pom.xml
+++ b/components/camel-crypto-pgp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-crypto/pom.xml
+++ b/components/camel-crypto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-csimple-joor/pom.xml
+++ b/components/camel-csimple-joor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-csv/pom.xml
+++ b/components/camel-csv/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-blueprint/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-spring-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-spring-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/camel-cxf-transport-jetty/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-jetty/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-cxf-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-cyberark-vault/pom.xml
+++ b/components/camel-cyberark-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dapr/pom.xml
+++ b/components/camel-dapr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dataformat/pom.xml
+++ b/components/camel-dataformat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dataset/pom.xml
+++ b/components/camel-dataset/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-datasonnet/pom.xml
+++ b/components/camel-datasonnet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-common/pom.xml
+++ b/components/camel-debezium/camel-debezium-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-db2/pom.xml
+++ b/components/camel-debezium/camel-debezium-db2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-mongodb/pom.xml
+++ b/components/camel-debezium/camel-debezium-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-mysql/pom.xml
+++ b/components/camel-debezium/camel-debezium-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-oracle/pom.xml
+++ b/components/camel-debezium/camel-debezium-oracle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-postgres/pom.xml
+++ b/components/camel-debezium/camel-debezium-postgres/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/camel-debezium-sqlserver/pom.xml
+++ b/components/camel-debezium/camel-debezium-sqlserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-debezium-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debezium/pom.xml
+++ b/components/camel-debezium/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-debug/pom.xml
+++ b/components/camel-debug/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dfdl/pom.xml
+++ b/components/camel-dfdl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dhis2/pom.xml
+++ b/components/camel-dhis2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-digitalocean/pom.xml
+++ b/components/camel-digitalocean/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-direct/pom.xml
+++ b/components/camel-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-directvm/pom.xml
+++ b/components/camel-directvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-directvm/src/generated/resources/META-INF/org/apache/camel/karaf/component/directvm/direct-vm.json
+++ b/components/camel-directvm/src/generated/resources/META-INF/org/apache/camel/karaf/component/directvm/direct-vm.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-directvm",
-    "version": "4.18.0-SNAPSHOT",
+    "version": "4.18.4-SNAPSHOT",
     "scheme": "direct-vm",
     "extendsScheme": "",
     "syntax": "direct-vm:name",

--- a/components/camel-disruptor/pom.xml
+++ b/components/camel-disruptor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dns/pom.xml
+++ b/components/camel-dns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-docker/pom.xml
+++ b/components/camel-docker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-drill/pom.xml
+++ b/components/camel-drill/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dropbox/pom.xml
+++ b/components/camel-dropbox/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dsl-support/pom.xml
+++ b/components/camel-dsl-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-dynamic-router/pom.xml
+++ b/components/camel-dynamic-router/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ehcache/pom.xml
+++ b/components/camel-ehcache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elasticsearch-rest-client/pom.xml
+++ b/components/camel-elasticsearch-rest-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elasticsearch/pom.xml
+++ b/components/camel-elasticsearch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-elytron/pom.xml
+++ b/components/camel-elytron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-exec/pom.xml
+++ b/components/camel-exec/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fastjson/pom.xml
+++ b/components/camel-fastjson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fhir/pom.xml
+++ b/components/camel-fhir/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-file-watch/pom.xml
+++ b/components/camel-file-watch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-file/pom.xml
+++ b/components/camel-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flatpack/pom.xml
+++ b/components/camel-flatpack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flink/pom.xml
+++ b/components/camel-flink/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-flowable/pom.xml
+++ b/components/camel-flowable/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fop/pom.xml
+++ b/components/camel-fop/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-fory/pom.xml
+++ b/components/camel-fory/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-freemarker/pom.xml
+++ b/components/camel-freemarker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ftp/pom.xml
+++ b/components/camel-ftp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-geocoder/pom.xml
+++ b/components/camel-geocoder/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-git/pom.xml
+++ b/components/camel-git/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-github/pom.xml
+++ b/components/camel-github/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-github2/pom.xml
+++ b/components/camel-github2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-bigquery/pom.xml
+++ b/components/camel-google/camel-google-bigquery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-calendar/pom.xml
+++ b/components/camel-google/camel-google-calendar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-drive/pom.xml
+++ b/components/camel-google/camel-google-drive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-functions/pom.xml
+++ b/components/camel-google/camel-google-functions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-mail/pom.xml
+++ b/components/camel-google/camel-google-mail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-pubsub-lite/pom.xml
+++ b/components/camel-google/camel-google-pubsub-lite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-secret-manager/pom.xml
+++ b/components/camel-google/camel-google-secret-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-sheets/pom.xml
+++ b/components/camel-google/camel-google-sheets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-storage/pom.xml
+++ b/components/camel-google/camel-google-storage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/camel-google-vertexai/pom.xml
+++ b/components/camel-google/camel-google-vertexai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-google-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-google/pom.xml
+++ b/components/camel-google/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grape/pom.xml
+++ b/components/camel-grape/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-graphql/pom.xml
+++ b/components/camel-graphql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grok/pom.xml
+++ b/components/camel-grok/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-groovy-xml/pom.xml
+++ b/components/camel-groovy-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-groovy/pom.xml
+++ b/components/camel-groovy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-grpc/pom.xml
+++ b/components/camel-grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-gson/pom.xml
+++ b/components/camel-gson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-guava-eventbus/pom.xml
+++ b/components/camel-guava-eventbus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hashicorp-vault/pom.xml
+++ b/components/camel-hashicorp-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hazelcast/pom.xml
+++ b/components/camel-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-headersmap/pom.xml
+++ b/components/camel-headersmap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-hl7/pom.xml
+++ b/components/camel-hl7/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http-base/pom.xml
+++ b/components/camel-http-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http-common/pom.xml
+++ b/components/camel-http-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-http/pom.xml
+++ b/components/camel-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-common/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-dms/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-dms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-frs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-frs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-iam/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-iam/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-obs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-obs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/camel-huaweicloud-smn/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-smn/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-huawei-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-huawei/pom.xml
+++ b/components/camel-huawei/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-cos/pom.xml
+++ b/components/camel-ibm/camel-ibm-cos/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-secrets-manager/pom.xml
+++ b/components/camel-ibm/camel-ibm-secrets-manager/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-discovery/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-language/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-language/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-speech-to-text/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-speech-to-text/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watson-text-to-speech/pom.xml
+++ b/components/camel-ibm/camel-ibm-watson-text-to-speech/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/camel-ibm-watsonx-ai/pom.xml
+++ b/components/camel-ibm/camel-ibm-watsonx-ai/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-ibm-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ibm/pom.xml
+++ b/components/camel-ibm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ical/pom.xml
+++ b/components/camel-ical/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iec60870/pom.xml
+++ b/components/camel-iec60870/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iggy/pom.xml
+++ b/components/camel-iggy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ignite/pom.xml
+++ b/components/camel-ignite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan-common/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan-embedded/pom.xml
+++ b/components/camel-infinispan/camel-infinispan-embedded/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/camel-infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-influxdb/pom.xml
+++ b/components/camel-influxdb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-influxdb2/pom.xml
+++ b/components/camel-influxdb2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-irc/pom.xml
+++ b/components/camel-irc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ironmq/pom.xml
+++ b/components/camel-ironmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-iso8583/pom.xml
+++ b/components/camel-iso8583/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson-avro/pom.xml
+++ b/components/camel-jackson-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson-protobuf/pom.xml
+++ b/components/camel-jackson-protobuf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jackson/pom.xml
+++ b/components/camel-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jacksonxml/pom.xml
+++ b/components/camel-jacksonxml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jandex/pom.xml
+++ b/components/camel-jandex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jasypt/pom.xml
+++ b/components/camel-jasypt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-javascript/pom.xml
+++ b/components/camel-javascript/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jaxb/pom.xml
+++ b/components/camel-jaxb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jcache/pom.xml
+++ b/components/camel-jcache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jcr/pom.xml
+++ b/components/camel-jcr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jdbc/pom.xml
+++ b/components/camel-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jetty-common/pom.xml
+++ b/components/camel-jetty-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jetty/pom.xml
+++ b/components/camel-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jfr/pom.xml
+++ b/components/camel-jfr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jgroups-raft/pom.xml
+++ b/components/camel-jgroups-raft/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jgroups/pom.xml
+++ b/components/camel-jgroups/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jira/pom.xml
+++ b/components/camel-jira/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jms/pom.xml
+++ b/components/camel-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jmx/pom.xml
+++ b/components/camel-jmx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jolt/pom.xml
+++ b/components/camel-jolt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jooq/pom.xml
+++ b/components/camel-jooq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-joor/pom.xml
+++ b/components/camel-joor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jpa/pom.xml
+++ b/components/camel-jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jq/pom.xml
+++ b/components/camel-jq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsch/pom.xml
+++ b/components/camel-jsch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jslt/pom.xml
+++ b/components/camel-jslt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-json-patch/pom.xml
+++ b/components/camel-json-patch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-json-validator/pom.xml
+++ b/components/camel-json-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonapi/pom.xml
+++ b/components/camel-jsonapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonata/pom.xml
+++ b/components/camel-jsonata/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonb/pom.xml
+++ b/components/camel-jsonb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jsonpath/pom.xml
+++ b/components/camel-jsonpath/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jt400/pom.xml
+++ b/components/camel-jt400/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jta/pom.xml
+++ b/components/camel-jta/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-jte/pom.xml
+++ b/components/camel-jte/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kafka/pom.xml
+++ b/components/camel-kafka/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kamelet/pom.xml
+++ b/components/camel-kamelet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-keycloak/pom.xml
+++ b/components/camel-keycloak/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/camel-knative-http/pom.xml
+++ b/components/camel-knative/camel-knative-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-knative-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/camel-knative/pom.xml
+++ b/components/camel-knative/camel-knative/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-knative-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-knative/pom.xml
+++ b/components/camel-knative/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kubernetes/pom.xml
+++ b/components/camel-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-kudu/pom.xml
+++ b/components/camel-kudu/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-language/pom.xml
+++ b/components/camel-language/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ldap/pom.xml
+++ b/components/camel-ldap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ldif/pom.xml
+++ b/components/camel-ldif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-leveldb/pom.xml
+++ b/components/camel-leveldb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-log/pom.xml
+++ b/components/camel-log/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lra/pom.xml
+++ b/components/camel-lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lucene/pom.xml
+++ b/components/camel-lucene/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lumberjack/pom.xml
+++ b/components/camel-lumberjack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-lzf/pom.xml
+++ b/components/camel-lzf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mail-microsoft-oauth/pom.xml
+++ b/components/camel-mail-microsoft-oauth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mapstruct/pom.xml
+++ b/components/camel-mapstruct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-master/pom.xml
+++ b/components/camel-master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mdc/pom.xml
+++ b/components/camel-mdc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-metrics/pom.xml
+++ b/components/camel-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer-observability/pom.xml
+++ b/components/camel-micrometer-observability/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer-prometheus/pom.xml
+++ b/components/camel-micrometer-prometheus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-micrometer/pom.xml
+++ b/components/camel-micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-config/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/camel-microprofile-health/pom.xml
+++ b/components/camel-microprofile/camel-microprofile-health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-microprofile/pom.xml
+++ b/components/camel-microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-milo/pom.xml
+++ b/components/camel-milo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mina-sftp/pom.xml
+++ b/components/camel-mina-sftp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mina/pom.xml
+++ b/components/camel-mina/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-minio/pom.xml
+++ b/components/camel-minio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mllp/pom.xml
+++ b/components/camel-mllp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mock/pom.xml
+++ b/components/camel-mock/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mongodb-gridfs/pom.xml
+++ b/components/camel-mongodb-gridfs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mongodb/pom.xml
+++ b/components/camel-mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mustache/pom.xml
+++ b/components/camel-mustache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mvel/pom.xml
+++ b/components/camel-mvel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-mybatis/pom.xml
+++ b/components/camel-mybatis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-nats/pom.xml
+++ b/components/camel-nats/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-netty-http/pom.xml
+++ b/components/camel-netty-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-netty/pom.xml
+++ b/components/camel-netty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-nitrite/pom.xml
+++ b/components/camel-nitrite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-oaipmh/pom.xml
+++ b/components/camel-oaipmh/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-oauth/pom.xml
+++ b/components/camel-oauth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-observability-services/pom.xml
+++ b/components/camel-observability-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-observation/pom.xml
+++ b/components/camel-observation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ocsf/pom.xml
+++ b/components/camel-ocsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ognl/pom.xml
+++ b/components/camel-ognl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-olingo2/pom.xml
+++ b/components/camel-olingo2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-olingo4/pom.xml
+++ b/components/camel-olingo4/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-once/pom.xml
+++ b/components/camel-once/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openapi-java/pom.xml
+++ b/components/camel-openapi-java/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openapi-validator/pom.xml
+++ b/components/camel-openapi-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opensearch/pom.xml
+++ b/components/camel-opensearch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-openstack/pom.xml
+++ b/components/camel-openstack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry-metrics/pom.xml
+++ b/components/camel-opentelemetry-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry/pom.xml
+++ b/components/camel-opentelemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-opentelemetry2/pom.xml
+++ b/components/camel-opentelemetry2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-optaplanner/pom.xml
+++ b/components/camel-optaplanner/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-paho-mqtt5/pom.xml
+++ b/components/camel-paho-mqtt5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-paho/pom.xml
+++ b/components/camel-paho/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-parquet-avro/pom.xml
+++ b/components/camel-parquet-avro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pdf/pom.xml
+++ b/components/camel-pdf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pg-replication-slot/pom.xml
+++ b/components/camel-pg-replication-slot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pgevent/pom.xml
+++ b/components/camel-pgevent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-jolokia/pom.xml
+++ b/components/camel-platform-http-jolokia/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-main/pom.xml
+++ b/components/camel-platform-http-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http-vertx/pom.xml
+++ b/components/camel-platform-http-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-platform-http/pom.xml
+++ b/components/camel-platform-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-plc4x/pom.xml
+++ b/components/camel-plc4x/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pqc/pom.xml
+++ b/components/camel-pqc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-printer/pom.xml
+++ b/components/camel-printer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-protobuf/pom.xml
+++ b/components/camel-protobuf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pubnub/pom.xml
+++ b/components/camel-pubnub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-pulsar/pom.xml
+++ b/components/camel-pulsar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-python/pom.xml
+++ b/components/camel-python/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-quartz/pom.xml
+++ b/components/camel-quartz/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-quickfix/pom.xml
+++ b/components/camel-quickfix/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-executor-tomcat/pom.xml
+++ b/components/camel-reactive-executor-tomcat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-executor-vertx/pom.xml
+++ b/components/camel-reactive-executor-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactive-streams/pom.xml
+++ b/components/camel-reactive-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-reactor/pom.xml
+++ b/components/camel-reactor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-redis/pom.xml
+++ b/components/camel-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ref/pom.xml
+++ b/components/camel-ref/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resilience4j-micrometer/pom.xml
+++ b/components/camel-resilience4j-micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resilience4j/pom.xml
+++ b/components/camel-resilience4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-resourceresolver-github/pom.xml
+++ b/components/camel-resourceresolver-github/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rest-openapi/pom.xml
+++ b/components/camel-rest-openapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rest/pom.xml
+++ b/components/camel-rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-robotframework/pom.xml
+++ b/components/camel-robotframework/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rocketmq/pom.xml
+++ b/components/camel-rocketmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rss/pom.xml
+++ b/components/camel-rss/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-rxjava/pom.xml
+++ b/components/camel-rxjava/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-saga/pom.xml
+++ b/components/camel-saga/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-salesforce/pom.xml
+++ b/components/camel-salesforce/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sap-netweaver/pom.xml
+++ b/components/camel-sap-netweaver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-saxon/pom.xml
+++ b/components/camel-saxon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-scheduler/pom.xml
+++ b/components/camel-scheduler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-schematron/pom.xml
+++ b/components/camel-schematron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-seda/pom.xml
+++ b/components/camel-seda/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-service/pom.xml
+++ b/components/camel-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-servicenow/pom.xml
+++ b/components/camel-servicenow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-servlet/pom.xml
+++ b/components/camel-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-shiro/pom.xml
+++ b/components/camel-shiro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sjms/pom.xml
+++ b/components/camel-sjms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sjms2/pom.xml
+++ b/components/camel-sjms2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smb/pom.xml
+++ b/components/camel-smb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smooks/pom.xml
+++ b/components/camel-smooks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-smpp/pom.xml
+++ b/components/camel-smpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-snakeyaml/pom.xml
+++ b/components/camel-snakeyaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-snmp/pom.xml
+++ b/components/camel-snmp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-soap/pom.xml
+++ b/components/camel-soap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-solr/pom.xml
+++ b/components/camel-solr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-splunk-hec/pom.xml
+++ b/components/camel-splunk-hec/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-splunk/pom.xml
+++ b/components/camel-splunk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-batch/pom.xml
+++ b/components/camel-spring-parent/camel-spring-batch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-cloud-config/pom.xml
+++ b/components/camel-spring-parent/camel-spring-cloud-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-jdbc/pom.xml
+++ b/components/camel-spring-parent/camel-spring-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-ldap/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ldap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-main/pom.xml
+++ b/components/camel-spring-parent/camel-spring-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
+++ b/components/camel-spring-parent/camel-spring-rabbitmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-redis/pom.xml
+++ b/components/camel-spring-parent/camel-spring-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-security/pom.xml
+++ b/components/camel-spring-parent/camel-spring-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-ws/pom.xml
+++ b/components/camel-spring-parent/camel-spring-ws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring-xml/pom.xml
+++ b/components/camel-spring-parent/camel-spring-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-spring/pom.xml
+++ b/components/camel-spring-parent/camel-spring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/camel-undertow-spring-security/pom.xml
+++ b/components/camel-spring-parent/camel-undertow-spring-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-spring-parent-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-spring-parent/pom.xml
+++ b/components/camel-spring-parent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-sql/pom.xml
+++ b/components/camel-sql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-ssh/pom.xml
+++ b/components/camel-ssh/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stax/pom.xml
+++ b/components/camel-stax/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stitch/pom.xml
+++ b/components/camel-stitch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stomp/pom.xml
+++ b/components/camel-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stream/pom.xml
+++ b/components/camel-stream/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stringtemplate/pom.xml
+++ b/components/camel-stringtemplate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stripe/pom.xml
+++ b/components/camel-stripe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-stub/pom.xml
+++ b/components/camel-stub/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-swift/pom.xml
+++ b/components/camel-swift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-syslog/pom.xml
+++ b/components/camel-syslog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tahu/pom.xml
+++ b/components/camel-tahu/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tarfile/pom.xml
+++ b/components/camel-tarfile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telegram/pom.xml
+++ b/components/camel-telegram/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telemetry-dev/pom.xml
+++ b/components/camel-telemetry-dev/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-telemetry/pom.xml
+++ b/components/camel-telemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-junit5/pom.xml
+++ b/components/camel-test/camel-test-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-junit6/pom.xml
+++ b/components/camel-test/camel-test-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-main-junit6/pom.xml
+++ b/components/camel-test/camel-test-main-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-spring-junit5/pom.xml
+++ b/components/camel-test/camel-test-spring-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/camel-test-spring-junit6/pom.xml
+++ b/components/camel-test/camel-test-spring-junit6/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-test/pom.xml
+++ b/components/camel-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-threadpoolfactory-vertx/pom.xml
+++ b/components/camel-threadpoolfactory-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-thrift/pom.xml
+++ b/components/camel-thrift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-thymeleaf/pom.xml
+++ b/components/camel-thymeleaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tika/pom.xml
+++ b/components/camel-tika/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-timer/pom.xml
+++ b/components/camel-timer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-tracing/pom.xml
+++ b/components/camel-tracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-twilio/pom.xml
+++ b/components/camel-twilio/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-twitter/pom.xml
+++ b/components/camel-twitter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-undertow/pom.xml
+++ b/components/camel-undertow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-univocity-parsers/pom.xml
+++ b/components/camel-univocity-parsers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-validator/pom.xml
+++ b/components/camel-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-velocity/pom.xml
+++ b/components/camel-velocity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-common/pom.xml
+++ b/components/camel-vertx/camel-vertx-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-http/pom.xml
+++ b/components/camel-vertx/camel-vertx-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx-websocket/pom.xml
+++ b/components/camel-vertx/camel-vertx-websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/camel-vertx/pom.xml
+++ b/components/camel-vertx/camel-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vertx/pom.xml
+++ b/components/camel-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vm/pom.xml
+++ b/components/camel-vm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-vm/src/generated/resources/META-INF/org/apache/camel/karaf/component/vm/vm.json
+++ b/components/camel-vm/src/generated/resources/META-INF/org/apache/camel/karaf/component/vm/vm.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.karaf",
     "artifactId": "camel-vm",
-    "version": "4.18.0-SNAPSHOT",
+    "version": "4.18.4-SNAPSHOT",
     "scheme": "vm",
     "extendsScheme": "",
     "syntax": "vm:name",

--- a/components/camel-wal/pom.xml
+++ b/components/camel-wal/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-wasm/pom.xml
+++ b/components/camel-wasm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-weather/pom.xml
+++ b/components/camel-weather/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-web3j/pom.xml
+++ b/components/camel-web3j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-webhook/pom.xml
+++ b/components/camel-webhook/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-whatsapp/pom.xml
+++ b/components/camel-whatsapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-wordpress/pom.xml
+++ b/components/camel-wordpress/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-workday/pom.xml
+++ b/components/camel-workday/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xchange/pom.xml
+++ b/components/camel-xchange/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xj/pom.xml
+++ b/components/camel-xj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xml-io-dsl/pom.xml
+++ b/components/camel-xml-io-dsl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xmlsecurity/pom.xml
+++ b/components/camel-xmlsecurity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xmpp/pom.xml
+++ b/components/camel-xmpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xpath/pom.xml
+++ b/components/camel-xpath/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xslt-saxon/pom.xml
+++ b/components/camel-xslt-saxon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-xslt/pom.xml
+++ b/components/camel-xslt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-yaml-dsl/pom.xml
+++ b/components/camel-yaml-dsl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zeebe/pom.xml
+++ b/components/camel-zeebe/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zendesk/pom.xml
+++ b/components/camel-zendesk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zip-deflater/pom.xml
+++ b/components/camel-zip-deflater/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zipfile/pom.xml
+++ b/components/camel-zipfile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zookeeper-master/pom.xml
+++ b/components/camel-zookeeper-master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/camel-zookeeper/pom.xml
+++ b/components/camel-zookeeper/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-api/pom.xml
+++ b/core/camel-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-base-engine/pom.xml
+++ b/core/camel-base-engine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-base/pom.xml
+++ b/core/camel-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-cloud/pom.xml
+++ b/core/camel-cloud/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-cluster/pom.xml
+++ b/core/camel-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-console/pom.xml
+++ b/core/camel-console/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-catalog/pom.xml
+++ b/core/camel-core-catalog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-engine/pom.xml
+++ b/core/camel-core-engine/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-languages/pom.xml
+++ b/core/camel-core-languages/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-model/pom.xml
+++ b/core/camel-core-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-processor/pom.xml
+++ b/core/camel-core-processor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-reifier/pom.xml
+++ b/core/camel-core-reifier/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-core-xml/pom.xml
+++ b/core/camel-core-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-health/pom.xml
+++ b/core/camel-health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-main/pom.xml
+++ b/core/camel-main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-management-api/pom.xml
+++ b/core/camel-management-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-management/pom.xml
+++ b/core/camel-management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-support/pom.xml
+++ b/core/camel-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-tooling-model/pom.xml
+++ b/core/camel-tooling-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-util-json/pom.xml
+++ b/core/camel-util-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-util/pom.xml
+++ b/core/camel-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-io-util/pom.xml
+++ b/core/camel-xml-io-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-io/pom.xml
+++ b/core/camel-xml-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-jaxb/pom.xml
+++ b/core/camel-xml-jaxb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/camel-xml-jaxp/pom.xml
+++ b/core/camel-xml-jaxp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-core</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1570,7 +1570,7 @@
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${google-auth-library-oauth2-http-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-secretmanager-v1/${google-cloud-secretmanager-version}</bundle>
-        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf4-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-pubsub-v1/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-google-secret-manager/${project.version}</bundle>
     </feature>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1571,7 +1571,7 @@
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${google-auth-library-oauth2-http-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-secretmanager-v1/${google-cloud-secretmanager-version}</bundle>
-        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf4-version}</bundle>
+        <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-pubsub-v1/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-google-secret-manager/${project.version}</bundle>
     </feature>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1515,6 +1515,8 @@
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/gax/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/gax-grpc/${auto-detect-version}</bundle>
+        <!-- gax's com.google.api.gax.logging.LogData has a static dependency on Gson (used by the gRPC/HTTP logging interceptors) -->
+        <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-pubsub-v1/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
@@ -1553,6 +1555,8 @@
         <feature version="[33,34)">guava</feature>
         <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/gax/${auto-detect-version}</bundle>
+        <!-- gax's com.google.api.gax.logging.LogData has a static dependency on Gson (used by the gRPC/HTTP logging interceptors) -->
+        <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-cloud-pubsub-v1/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${google-auth-library-oauth2-http-version}</bundle>
@@ -1567,6 +1571,8 @@
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>        
         <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${auto-detect-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.api/gax/${auto-detect-version}</bundle>
+        <!-- gax's com.google.api.gax.logging.LogData has a static dependency on Gson (used by the gRPC/HTTP logging interceptors) -->
+        <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${google-auth-library-oauth2-http-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${google-auth-library-oauth2-http-version}</bundle>
         <bundle dependency='true'>wrap:mvn:com.google.cloud/google-cloud-pubsub/${auto-detect-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.camel.karaf</groupId>
     <artifactId>camel-karaf</artifactId>
-    <version>4.18.3-SNAPSHOT</version>
+    <version>4.18.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Camel :: Karaf</name>
@@ -90,7 +90,7 @@
         <javaVersion>17</javaVersion>
         <project.build.outputTimestamp>1779210140</project.build.outputTimestamp>
 
-        <camel-version>4.18.2</camel-version>
+        <camel-version>4.18.4</camel-version>
 
         <!-- START: Maven Properties defining the version of 3rd party libraries used in Camel -->
         <activemq-version>5.19.5</activemq-version>
@@ -124,20 +124,20 @@
         <box-java-sdk-version>4.16.3</box-java-sdk-version>
         <braintree-gateway-version>3.48.0</braintree-gateway-version>
         <bytebuddy-version>1.18.4</bytebuddy-version>
-        <c3p0-version>0.12.0</c3p0-version>
-        <caffeine-version>3.2.3</caffeine-version>
+        <c3p0-version>0.14.1</c3p0-version>
+        <caffeine-version>3.2.4</caffeine-version>
         <californium-version>3.14.0</californium-version>
         <californium-scandium-version>3.11.0</californium-scandium-version>
         <camel-lsp-version>1.34.0</camel-lsp-version>
         <camel-kamelets-catalog-version>4.17.0</camel-kamelets-catalog-version>
         <camunda-version>7.24.0</camunda-version>
-        <cassandra-driver-version>4.19.2</cassandra-driver-version>
+        <cassandra-driver-version>4.19.3</cassandra-driver-version>
         <jta-api-1-2-version>1.2</jta-api-1-2-version>
         <cglib-version>3.3.0</cglib-version>
         <checker-framework-version>3.53.1</checker-framework-version>
         <chicory-version>1.6.1</chicory-version>
         <chunk-templates-version>3.6.2</chunk-templates-version>
-        <citrus-version>4.10.0</citrus-version>
+        <citrus-version>4.10.3</citrus-version>
         <classgraph-version>4.8.184</classgraph-version>
         <cloudant-version>0.10.15</cloudant-version>
         <com-ibm-mq-jakarta-client-version>9.4.5.0</com-ibm-mq-jakarta-client-version>
@@ -222,7 +222,7 @@
         <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
         <jakarta-persistence-api-version>3.2.0</jakarta-persistence-api-version>
         <jakarta-json-api-version>2.1.3</jakarta-json-api-version>
-        <jakarta-json-bind-api-version>3.0.1</jakarta-json-bind-api-version>
+        <jakarta-json-bind-api-version>3.0.2</jakarta-json-bind-api-version>
         <jakarta-transaction-api-version>2.0.1</jakarta-transaction-api-version>
         <jakarta-jws-api-version>3.0.0</jakarta-jws-api-version>
         <jaxb-core-version>4.0.5</jaxb-core-version>
@@ -243,7 +243,7 @@
         <google-cloud-http-client-version>2.1.0</google-cloud-http-client-version>
         <google-cloud-pubsub-version>1.145.0</google-cloud-pubsub-version>
         <google-cloud-pubsublite-version>1.16.0</google-cloud-pubsublite-version>
-        <google-cloud-secretmanager-version>2.84.0</google-cloud-secretmanager-version>
+        <google-cloud-secretmanager-version>2.82.0</google-cloud-secretmanager-version>
         <google-cloud-storage-version>2.62.1</google-cloud-storage-version>
         <google-cloud-aiplatform-version>3.85.0</google-cloud-aiplatform-version>
         <google-genai-version>1.38.0</google-genai-version>
@@ -251,7 +251,7 @@
         <graphql-java-version>25.0</graphql-java-version>
         <greenmail-version>2.1.8</greenmail-version>
         <grizzly-websockets-version>2.4.4</grizzly-websockets-version>
-        <groovy-version>4.0.30</groovy-version>
+        <groovy-version>4.0.32</groovy-version>
         <grpc-version>1.79.0</grpc-version>
         <grpc-google-auth-library-version>1.41.0</grpc-google-auth-library-version>
         <grpc-java-jwt-version>4.5.0</grpc-java-jwt-version>
@@ -264,8 +264,8 @@
         <hamcrest-version>3.0</hamcrest-version>
         <hapi-version>2.6.0</hapi-version>
         <hapi-base-version>2.6.0</hapi-base-version>
-        <hapi-fhir-version>8.6.5</hapi-fhir-version>
-        <hapi-fhir-utilities-version>6.9.1</hapi-fhir-utilities-version>
+        <hapi-fhir-version>8.10.0</hapi-fhir-version>
+        <hapi-fhir-core-version>6.9.12</hapi-fhir-core-version>
         <hawtio-version>4.6.2</hawtio-version>
         <hazelcast-version>5.4.0</hazelcast-version>
         <hdrhistrogram-version>2.2.2</hdrhistrogram-version>
@@ -298,7 +298,7 @@
         <ivy-version>2.5.3</ivy-version>
         <jackson-databind-nullable-version>0.2.9</jackson-databind-nullable-version>
         <jackson-jq-version>1.6.0</jackson-jq-version>
-        <jackson2-version>2.21.2</jackson2-version>
+        <jackson2-version>2.21.4</jackson2-version>
         <jackson2-annotations-version>2.21</jackson2-annotations-version>
         <jackrabbit-version>2.22.3</jackrabbit-version>
         <jasminb-jsonapi-version>0.15</jasminb-jsonapi-version>
@@ -323,7 +323,7 @@
         <jakarta-xml-soap-api-version>3.0.2</jakarta-xml-soap-api-version>
         <jakarta-xml-ws-api-version>4.0.2</jakarta-xml-ws-api-version>
         <glassfish-javax-json>1.1.4</glassfish-javax-json>
-        <glassfish-jaxb-runtime-version>4.0.6</glassfish-jaxb-runtime-version>
+        <glassfish-jaxb-runtime-version>4.0.9</glassfish-jaxb-runtime-version>
         <jaxp-ri-version>1.4.5</jaxp-ri-version>
         <jboss-el-api_3-0_spec-version>2.0.0.Final</jboss-el-api_3-0_spec-version>
         <jboss-logging-version>3.6.2.Final</jboss-logging-version>
@@ -346,18 +346,18 @@
         <jgroups-raft-mapdb-version>1.0.8</jgroups-raft-mapdb-version>
         <jira-rest-client-api-version>6.0.2</jira-rest-client-api-version>
         <jline-version>3.30.6</jline-version>
-        <libthrift-version>0.22.0</libthrift-version>
+        <libthrift-version>0.24.0</libthrift-version>
         <jodatime2-version>2.14.0</jodatime2-version>
         <jolokia-version>2.5.0</jolokia-version>
         <jolt-version>0.1.8</jolt-version>
         <jool-version>0.9.15</jool-version>
-        <jooq-version>3.19.30</jooq-version>
+        <jooq-version>3.19.35</jooq-version>
         <joor-version>0.9.15</joor-version>
         <jose4j-version>0.9.3</jose4j-version>
         <johnzon-version>2.0.2</johnzon-version>
         <jslt-version>0.1.14</jslt-version>
         <jsmpp-version>3.0.1</jsmpp-version>
-        <jsch-version>2.28.0</jsch-version>
+        <jsch-version>2.28.2</jsch-version>
         <javax-json-api-version>1.1.4</javax-json-api-version>
         <jsonschema-generator-version>4.38.0</jsonschema-generator-version>
         <jsonassert-version>1.5.3</jsonassert-version>
@@ -393,19 +393,19 @@
         <libphonenumber-version>9.0.23</libphonenumber-version>
         <lifecycle-mapping-version>1.0.0</lifecycle-mapping-version>
         <log4j2-version>2.25.4</log4j2-version>
-        <logback-version>1.5.32</logback-version>
+        <logback-version>1.5.34</logback-version>
         <lucene-version>9.12.3</lucene-version>
         <lightcouch-version>0.2.0</lightcouch-version>
         <littleproxy-version>2.6.0</littleproxy-version>
         <lz4-java-version>1.10.3</lz4-java-version>
         <mapstruct-version>1.6.3</mapstruct-version>
         <metrics-version>4.2.38</metrics-version>
-        <micrometer-version>1.15.10</micrometer-version>
-        <micrometer-tracing-version>1.5.10</micrometer-tracing-version>
+        <micrometer-version>1.15.12</micrometer-version>
+        <micrometer-tracing-version>1.5.12</micrometer-tracing-version>
         <microprofile-config-version>3.1</microprofile-config-version>
         <milo-version>1.1.1</milo-version>
         <milvus-client-version>2.6.14</milvus-client-version>
-        <mina-version>2.2.5</mina-version>
+        <mina-version>2.2.7</mina-version>
         <minidns-version>0.3.4</minidns-version>
         <minimal-json-version>0.9.5</minimal-json-version>
         <minio-version>8.6.0</minio-version>
@@ -471,7 +471,7 @@
         <pulsar-version>4.1.2</pulsar-version>
         <qdrant-client-version>1.16.2</qdrant-client-version>
         <qpid-broker-version>10.0.1</qpid-broker-version>
-        <qpid-proton-j-version>0.34.1</qpid-proton-j-version>
+        <qpid-proton-j-version>0.35.0</qpid-proton-j-version>
         <qpid-jms-client-version>2.10.0</qpid-jms-client-version>
         <quarkus-extension-registry-base-url>https://registry.quarkus.io</quarkus-extension-registry-base-url>
         <quarkus-mcp-server-version>1.10.0</quarkus-mcp-server-version>
@@ -496,7 +496,7 @@
         <shiro-version>2.1.0</shiro-version>
         <slack-api-model-version>1.47.0</slack-api-model-version>
         <slf4j-api-version>2.0.17</slf4j-api-version>
-        <slf4j-version>2.0.17</slf4j-version>
+        <slf4j-version>2.0.18</slf4j-version>
         <smack-version>4.3.5</smack-version>
         <smallrye-config-version>3.16.0</smallrye-config-version>
         <smallrye-health-version>4.3.0</smallrye-health-version>
@@ -513,15 +513,15 @@
         <spock-version>2.4-groovy-4.0</spock-version>
         <spring-ai-version>1.1.2</spring-ai-version>
         <spring-cloud-config-version>4.3.0</spring-cloud-config-version>
-        <spring-batch-version>5.2.5</spring-batch-version>
-        <spring-boot-version>3.5.13</spring-boot-version>
-        <spring-data-redis-version>3.5.5</spring-data-redis-version>
-        <spring-ldap-version>3.3.6</spring-ldap-version>
+        <spring-batch-version>5.2.6</spring-batch-version>
+        <spring-boot-version>3.5.16</spring-boot-version>
+        <spring-data-redis-version>3.5.13</spring-data-redis-version>
+        <spring-ldap-version>3.3.8</spring-ldap-version>
         <spring-vault-core-version>3.2.0</spring-vault-core-version>
-        <spring-version>6.2.17</spring-version>
+        <spring-version>6.2.19</spring-version>
         <spring-rabbitmq-version>3.2.9</spring-rabbitmq-version>
-        <spring-security-version>6.5.9</spring-security-version>
-        <spring-ws-version>4.1.3</spring-ws-version>
+        <spring-security-version>6.5.11</spring-security-version>
+        <spring-ws-version>4.1.4</spring-ws-version>
         <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
         <squareup-okhttp5-version>5.3.2</squareup-okhttp5-version>
         <squareup-okio-version>1.17.5</squareup-okio-version>
@@ -542,7 +542,7 @@
         <tika-version>3.2.3</tika-version>
         <twilio-version>11.3.3</twilio-version>
         <twitter4j-version>4.1.2</twitter4j-version>
-        <undertow-version>2.3.23.Final</undertow-version>
+        <undertow-version>2.3.24.Final</undertow-version>
         <univocity-parsers-version>2.10.2</univocity-parsers-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
         <vavr-version>1.0.0</vavr-version>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-blueprint-main/pom.xml
+++ b/tests/camel-blueprint-main/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-integration-test/pom.xml
+++ b/tests/camel-integration-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-test-blueprint-junit5/pom.xml
+++ b/tests/camel-test-blueprint-junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/camel-test-scr/pom.xml
+++ b/tests/camel-test-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/examples/blueprint-dsl-only/pom.xml
+++ b/tests/examples/blueprint-dsl-only/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-blueprint-dsl-only-test</artifactId>

--- a/tests/examples/java-dsl-only/pom.xml
+++ b/tests/examples/java-dsl-only/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-java-dsl-only-test</artifactId>

--- a/tests/examples/mixed/pom.xml
+++ b/tests/examples/mixed/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-examples-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-examples-mixed-test</artifactId>

--- a/tests/examples/pom.xml
+++ b/tests/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-activemq/pom.xml
+++ b/tests/features/camel-activemq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-activemq-test</artifactId>

--- a/tests/features/camel-amqp/pom.xml
+++ b/tests/features/camel-amqp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-amqp-test</artifactId>

--- a/tests/features/camel-arangodb/pom.xml
+++ b/tests/features/camel-arangodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-as2/pom.xml
+++ b/tests/features/camel-as2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-as2-test</artifactId>

--- a/tests/features/camel-asn1/pom.xml
+++ b/tests/features/camel-asn1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-asn1-test</artifactId>

--- a/tests/features/camel-atom/pom.xml
+++ b/tests/features/camel-atom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-atom-test</artifactId>

--- a/tests/features/camel-avro/pom.xml
+++ b/tests/features/camel-avro/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-avro-test</artifactId>

--- a/tests/features/camel-aws2-iam/pom.xml
+++ b/tests/features/camel-aws2-iam/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-iam-test</artifactId>

--- a/tests/features/camel-aws2-kinesis/pom.xml
+++ b/tests/features/camel-aws2-kinesis/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-kinesis-test</artifactId>

--- a/tests/features/camel-aws2-s3/pom.xml
+++ b/tests/features/camel-aws2-s3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-s3-test</artifactId>

--- a/tests/features/camel-aws2-ses/pom.xml
+++ b/tests/features/camel-aws2-ses/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-ses-test</artifactId>

--- a/tests/features/camel-aws2-sns/pom.xml
+++ b/tests/features/camel-aws2-sns/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sns-test</artifactId>

--- a/tests/features/camel-aws2-sqs/pom.xml
+++ b/tests/features/camel-aws2-sqs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sqs-test</artifactId>

--- a/tests/features/camel-aws2-sts/pom.xml
+++ b/tests/features/camel-aws2-sts/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-aws2-sts-test</artifactId>

--- a/tests/features/camel-azure-eventhubs/pom.xml
+++ b/tests/features/camel-azure-eventhubs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-eventhubs-test</artifactId>

--- a/tests/features/camel-azure-storage-blob/pom.xml
+++ b/tests/features/camel-azure-storage-blob/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-storage-blob-test</artifactId>

--- a/tests/features/camel-azure-storage-queue/pom.xml
+++ b/tests/features/camel-azure-storage-queue/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-azure-storage-queue-test</artifactId>

--- a/tests/features/camel-barcode/pom.xml
+++ b/tests/features/camel-barcode/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-barcode-test</artifactId>

--- a/tests/features/camel-base64/pom.xml
+++ b/tests/features/camel-base64/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-base64-test</artifactId>

--- a/tests/features/camel-bean-validator/pom.xml
+++ b/tests/features/camel-bean-validator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-bean-validator-test</artifactId>

--- a/tests/features/camel-bindy/pom.xml
+++ b/tests/features/camel-bindy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-bindy-test</artifactId>

--- a/tests/features/camel-caffeine/pom.xml
+++ b/tests/features/camel-caffeine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-caffeine-test</artifactId>

--- a/tests/features/camel-cbor/pom.xml
+++ b/tests/features/camel-cbor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cbor-test</artifactId>

--- a/tests/features/camel-chatscript/pom.xml
+++ b/tests/features/camel-chatscript/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-chatscript-test</artifactId>

--- a/tests/features/camel-coap/pom.xml
+++ b/tests/features/camel-coap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-coap-test</artifactId>

--- a/tests/features/camel-cometd/pom.xml
+++ b/tests/features/camel-cometd/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cometd-test</artifactId>

--- a/tests/features/camel-consul/pom.xml
+++ b/tests/features/camel-consul/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-consul-test</artifactId>

--- a/tests/features/camel-core/pom.xml
+++ b/tests/features/camel-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-couchdb/pom.xml
+++ b/tests/features/camel-couchdb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-couchdb-test</artifactId>

--- a/tests/features/camel-crypto/pom.xml
+++ b/tests/features/camel-crypto/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-crypto-test</artifactId>

--- a/tests/features/camel-csv/pom.xml
+++ b/tests/features/camel-csv/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-csv-test</artifactId>

--- a/tests/features/camel-cxf-jetty/pom.xml
+++ b/tests/features/camel-cxf-jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cxf-jetty-test</artifactId>

--- a/tests/features/camel-cxf-jetty/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-cxf-jetty/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -34,7 +34,7 @@
         <route id="cxf-jetty-route">
             <from uri="cxf:bean:cxfJettyEndpoint"/>
             <setBody>
-                <simple>${header.operationName} ${body}</simple>
+                <simple>${header.CamelCxfOperationName} ${body}</simple>
             </setBody>
         </route>
     </camelContext>

--- a/tests/features/camel-cxf/pom.xml
+++ b/tests/features/camel-cxf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-cxf-test</artifactId>

--- a/tests/features/camel-cxf/src/main/java/org/apache/karaf/camel/test/CamelCxfRsRouteSupplier.java
+++ b/tests/features/camel-cxf/src/main/java/org/apache/karaf/camel/test/CamelCxfRsRouteSupplier.java
@@ -40,7 +40,7 @@ public class CamelCxfRsRouteSupplier implements CamelRouteSupplier {
     @Override
     public void createRoutes(RouteBuilder builder) {
         builder.from(CXF_RS_ENDPOINT_URI)
-                .recipientList(builder.simple("direct:${header.operationName}"));
+                .recipientList(builder.simple("direct:${header.CamelCxfOperationName}"));
 
         builder.from("direct:getCustomer").process(exchange -> {
             assertEquals("123", exchange.getIn().getHeader("id"));

--- a/tests/features/camel-cxf/src/main/resources/OSGI-INF/blueprint/route.xml
+++ b/tests/features/camel-cxf/src/main/resources/OSGI-INF/blueprint/route.xml
@@ -34,7 +34,7 @@
         <route id="rss-route">
             <from uri="cxfrs:bean:rss?bindingStyle=SimpleConsumer"/>
             <recipientList>
-                <simple>direct-vm:${header.operationName}</simple>
+                <simple>direct-vm:${header.CamelCxfOperationName}</simple>
             </recipientList>
         </route>
     </camelContext>

--- a/tests/features/camel-debezium-mongodb/pom.xml
+++ b/tests/features/camel-debezium-mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-mongodb-test</artifactId>

--- a/tests/features/camel-debezium-mysql/pom.xml
+++ b/tests/features/camel-debezium-mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-mysql-test</artifactId>

--- a/tests/features/camel-debezium-postgres/pom.xml
+++ b/tests/features/camel-debezium-postgres/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-debezium-postgres-test</artifactId>

--- a/tests/features/camel-disruptor/pom.xml
+++ b/tests/features/camel-disruptor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-disruptor-test</artifactId>

--- a/tests/features/camel-dns/pom.xml
+++ b/tests/features/camel-dns/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-dns-test</artifactId>

--- a/tests/features/camel-dns/src/main/java/org/apache/karaf/camel/test/CamelDnsRouteSupplier.java
+++ b/tests/features/camel-dns/src/main/java/org/apache/karaf/camel/test/CamelDnsRouteSupplier.java
@@ -46,17 +46,17 @@ public class CamelDnsRouteSupplier extends AbstractCamelSingleFeatureResultMockB
     @Override
     protected void configureProducer(RouteBuilder builder, RouteDefinition producerRoute) {
         producerRoute.log("Will get IP")
-        .setHeader("dns.domain", builder.constant(LOCALHOST))
+        .setHeader("CamelDnsDomain", builder.constant(LOCALHOST))
         .to("dns:ip")
         .log("IP: ${body}")
         .toF("mock:%s", getResultMockName())
         .log("Will lookup")
-        .setHeader("dns.name", builder.constant(LOCALHOST))
+        .setHeader("CamelDnsName", builder.constant(LOCALHOST))
         .to("dns:lookup")
         .log("Lookup: ${body}")
         .toF("mock:%s", getResultMockName())
         .log("Will dig")
-        .setHeader("dns.type", builder.constant("A"))
+        .setHeader("CamelDnsType", builder.constant("A"))
         .to("dns:dig")
         .log("Dig: ${body}")
         .toF("mock:%s", getResultMockName());

--- a/tests/features/camel-docker/pom.xml
+++ b/tests/features/camel-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-docker-test</artifactId>

--- a/tests/features/camel-drill/pom.xml
+++ b/tests/features/camel-drill/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-drill-test</artifactId>

--- a/tests/features/camel-ehcache/pom.xml
+++ b/tests/features/camel-ehcache/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-ehcache-test</artifactId>

--- a/tests/features/camel-elasticsearch/pom.xml
+++ b/tests/features/camel-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-elasticsearch/src/main/java/org/apache/karaf/camel/test/CamelElasticsearchRouteSupplier.java
+++ b/tests/features/camel-elasticsearch/src/main/java/org/apache/karaf/camel/test/CamelElasticsearchRouteSupplier.java
@@ -56,7 +56,7 @@ public class CamelElasticsearchRouteSupplier extends AbstractCamelSingleFeatureR
                     .setHeader("_ID", builder.simple("${body}"))
                     .toF("elasticsearch://elasticsearch?operation=GetById&indexName=%s", INDEX_NAME)
                     .log("Get doc: ${body}")
-                    .setHeader("indexId", builder.simple("${header._ID}"))
+                    .setHeader("CamelElasticsearchIndexId", builder.simple("${header._ID}"))
                     .setBody(builder.constant("""
                             {"doc": {"someKey": "someValue2"}}
                             """))

--- a/tests/features/camel-exec/pom.xml
+++ b/tests/features/camel-exec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-exec-test</artifactId>

--- a/tests/features/camel-fastjson/pom.xml
+++ b/tests/features/camel-fastjson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-fastjson-test</artifactId>

--- a/tests/features/camel-flatpack/pom.xml
+++ b/tests/features/camel-flatpack/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-flatpack-test</artifactId>

--- a/tests/features/camel-ftp/pom.xml
+++ b/tests/features/camel-ftp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-ftp-test</artifactId>

--- a/tests/features/camel-google-pubsub/pom.xml
+++ b/tests/features/camel-google-pubsub/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/features/camel-groovy/pom.xml
+++ b/tests/features/camel-groovy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-groovy-test</artifactId>

--- a/tests/features/camel-gson/pom.xml
+++ b/tests/features/camel-gson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-gson-test</artifactId>

--- a/tests/features/camel-hazelcast/pom.xml
+++ b/tests/features/camel-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-hazelcast-test</artifactId>

--- a/tests/features/camel-http/pom.xml
+++ b/tests/features/camel-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-http-test</artifactId>

--- a/tests/features/camel-influxdb2/pom.xml
+++ b/tests/features/camel-influxdb2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-influxdb2-test</artifactId>

--- a/tests/features/camel-jackson-avro/pom.xml
+++ b/tests/features/camel-jackson-avro/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-avro-test</artifactId>

--- a/tests/features/camel-jackson-protobuf/pom.xml
+++ b/tests/features/camel-jackson-protobuf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-protobuf-test</artifactId>

--- a/tests/features/camel-jackson/pom.xml
+++ b/tests/features/camel-jackson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jackson-test</artifactId>

--- a/tests/features/camel-jacksonxml/pom.xml
+++ b/tests/features/camel-jacksonxml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jacksonxml-test</artifactId>

--- a/tests/features/camel-jaxb/pom.xml
+++ b/tests/features/camel-jaxb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jaxb-test</artifactId>

--- a/tests/features/camel-jcache/pom.xml
+++ b/tests/features/camel-jcache/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jcache-test</artifactId>

--- a/tests/features/camel-jetty/pom.xml
+++ b/tests/features/camel-jetty/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jetty-test</artifactId>

--- a/tests/features/camel-jms/pom.xml
+++ b/tests/features/camel-jms/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jms-test</artifactId>

--- a/tests/features/camel-kafka/pom.xml
+++ b/tests/features/camel-kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-kafka-test</artifactId>

--- a/tests/features/camel-leveldb/pom.xml
+++ b/tests/features/camel-leveldb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-leveldb-test</artifactId>

--- a/tests/features/camel-mail/pom.xml
+++ b/tests/features/camel-mail/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-mail-test</artifactId>

--- a/tests/features/camel-netty-http/pom.xml
+++ b/tests/features/camel-netty-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-netty-http-test</artifactId>

--- a/tests/features/camel-olingo2/pom.xml
+++ b/tests/features/camel-olingo2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-olingo2-test</artifactId>

--- a/tests/features/camel-paho-mqtt5/pom.xml
+++ b/tests/features/camel-paho-mqtt5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-paho-mqtt5-test</artifactId>

--- a/tests/features/camel-quartz/pom.xml
+++ b/tests/features/camel-quartz/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-quartz-test</artifactId>

--- a/tests/features/camel-saxon/pom.xml
+++ b/tests/features/camel-saxon/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-saxon-test</artifactId>

--- a/tests/features/camel-spring-rabbitmq/pom.xml
+++ b/tests/features/camel-spring-rabbitmq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-spring-rabbitmq-test</artifactId>

--- a/tests/features/camel-tika/pom.xml
+++ b/tests/features/camel-tika/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-tika-test</artifactId>

--- a/tests/features/camel-velocity/pom.xml
+++ b/tests/features/camel-velocity/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-velocity-test</artifactId>

--- a/tests/features/camel-weather/pom.xml
+++ b/tests/features/camel-weather/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-weather-test</artifactId>

--- a/tests/features/camel-xslt-saxon/pom.xml
+++ b/tests/features/camel-xslt-saxon/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-features-test</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-xslt-saxon-test</artifactId>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-tests</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tooling/camel-karaf-feature-maven-plugin/pom.xml
+++ b/tooling/camel-karaf-feature-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
     
     <artifactId>camel-karaf-feature-maven-plugin</artifactId>

--- a/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
+++ b/tooling/camel-karaf-maven-plugin-integration-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
     
     <artifactId>camel-karaf-maven-plugin-integration-test</artifactId>

--- a/tooling/camel-karaf-test-feature-archetype/pom.xml
+++ b/tooling/camel-karaf-test-feature-archetype/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-karaf-test-feature-archetype</artifactId>

--- a/tooling/camel-upgrade/pom.xml
+++ b/tooling/camel-upgrade/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-upgrade</artifactId>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf</artifactId>
-        <version>4.18.3-SNAPSHOT</version>
+        <version>4.18.4-SNAPSHOT</version>
     </parent>
     
     <artifactId>tooling</artifactId>


### PR DESCRIPTION
Used the tooling to list and apply changes from camel 4.18.4.

I made some fixes due to this upgrade:

- `camel-google-secret-manager` : applied https://issues.apache.org/jira/browse/CAMEL-23729 => protobuf rolled-back to ${protobuf-version} instead of ${protobuf4-version} due  to google-cloud-secretmanager downgrade to 2.82.0 in Camel 4.18.3
- `tests` : renamed camel headers 
  - operationName→CamelCxfOperationName
  - dns.*→CamelDns\*
  - indexId→CamelElasticsearchIndexId
- `features` : added `com.google.code.gson/gson` to `camel-google-pubsub`, `camel-google-pubsub-lite` and `camel-google-secret-manager`. Camel 4.18.4 pulls gax 2.73.x, whose `com.google.api.gax.logging.LogData` has a static dependency on Gson (loaded by the gRPC/HTTP logging interceptors). Without it every gax call fails with `NoClassDefFoundError` / `ClassNotFoundException: com.google.gson.Gson not found by wrap_com.google.api.gax`, which made `CamelGooglePubsubITest` time out with 0 messages on CI. These three features wrap `com.google.api/gax` plainly (no optional-import override) and did not already provide gson. _Diagnosed and committed by Claude Code on behalf of JB Onofré._