### PR TITLE
fix(#745): bump the Pub/Sub emulator image to a tag gcr.io still serves

### DIFF
--- a/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
+++ b/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
@@ -64,9 +64,15 @@ public class CamelGooglePubsubITest extends AbstractCamelSingleFeatureResultMock
         static final String TEST_TOPIC = "test-topic";
         static final String TEST_SUBSCRIPTION = "test-subscription";
 
+        // gcr.io only retains a rolling window of the most recent google-cloud-cli emulator tags
+        // (~49 at the time of writing), so an exact pin eventually stops resolving and the itest
+        // fails with "manifest unknown". Bump this to a current tag when that happens.
+        private static final String PUB_SUB_EMULATOR_IMAGE
+                = "gcr.io/google.com/cloudsdktool/google-cloud-cli:583.0.0-emulators";
+
         public static GenericContainerResource<PubSubEmulatorContainer> createPubsubContainer() {
             final PubSubEmulatorContainer pubSubEmulatorContainer = new PubSubEmulatorContainer(
-                    DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators"));
+                    DockerImageName.parse(PUB_SUB_EMULATOR_IMAGE));
 
             return new GenericContainerResource<>(pubSubEmulatorContainer, resource -> {
                 setUpEmulator(pubSubEmulatorContainer);


### PR DESCRIPTION
Fixes #745.

## Problem

Every `Test (Java 17)` / `Test (Java 21)` job fails in `camel-google-pubsub-test`:

```
CamelGooglePubsubITest.initializationError
  » ContainerFetch Can't get Docker image:
    gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators

Caused by: NotFoundException: Status 404: manifest for ...:441.0.0-emulators
  not found: manifest unknown
```

The tag pinned in `CamelGooglePubsubITest` (added in aca82e14a, #379) has been pruned from `gcr.io`. Querying the registry today: `google-cloud-cli` serves 2076 tags, of which only **49** match `X.Y.Z-emulators`, spanning `537.0.0-emulators` to `583.0.0-emulators`. `441.0.0-emulators` returns a `404` manifest; `583.0.0-emulators` returns `200`.

So the registry keeps a **rolling window of roughly the last 49 releases** — the pin was always going to rot, and it has.

This is not specific to any one PR: the push build for 6f2d1e26b on `main` fails identically (run [33491325010](https://github.com/apache/camel-karaf/actions/runs/33491325010)). Because the reactor halts at this module, **33 later modules are skipped**, so no PR can currently get a green `Test` job and regressions in later modules are invisible.

## Fix

Bump the pin to `583.0.0-emulators` and lift it into a named constant carrying a comment about the retention window, so the next occurrence is diagnosable instead of mysterious.

Nothing else in the test changes. It drives the emulator through the stable `TopicAdminClient` / `SubscriptionAdminClient` admin APIs and the default emulator port (8085), none of which differ across these image versions, and Testcontainers 2.0.3's `PubSubEmulatorContainer` supplies the startup command.

## Scope

I checked the other four pinned test images while I was here — `confluentinc/cp-kafka:7.6.1`, `influxdb:2.0.7`, `localstack/localstack:3.4.0` and `rabbitmq:3.13.1` all still resolve, so only the gcr.io pin was affected and the other four are untouched.

## On pinning vs. floating

I kept an exact pin, matching the convention used by the other four images: it stays reproducible, and the comment tells the next person what to do. The trade-off is that this *will* rot again in about a year.

The alternative is the floating `emulators` tag, which never 404s but gives up reproducibility and can change emulator behaviour under the test without warning. Happy to switch if reviewers would rather not revisit this — it is a one-word change.

## Verification

- Registry state verified directly against the gcr.io v2 API: old tag `404`, new tag `200`, retention window as described above.
- The itest itself is **not run locally** — I have no Docker available in this environment — so the actual container start-up is validated by CI on this PR, which is precisely the check that was failing.
- Expect this PR's `Test` jobs to get past `camel-google-pubsub-test` and, for the first time in a while, exercise the 33 modules that were being skipped. Those modules have not had CI coverage since the tag was pruned, so please treat any new failure they surface as pre-existing rather than caused by this change.

---
_Claude Code on behalf of JB Onofré_
