### PR TITLE
ci: bump the Google Cloud SDK emulator image to a tag that still exists

### DIFF
--- a/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
+++ b/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
@@ -64,9 +64,14 @@ public class CamelGooglePubsubITest extends AbstractCamelSingleFeatureResultMock
         static final String TEST_TOPIC = "test-topic";
         static final String TEST_SUBSCRIPTION = "test-subscription";
 
+        // gcr.io keeps only a rolling window of google-cloud-cli tags - at the time of writing 49 of them, from
+        // 537.0.0-emulators up. Older tags are deleted outright rather than archived, so a pin that has fallen out
+        // of the window fails the build with a 404 "manifest unknown" rather than anything that looks like a test
+        // failure. When that happens, move this to a current tag; the floating "emulators" tag would never 404 but
+        // would also make the build non-reproducible.
         public static GenericContainerResource<PubSubEmulatorContainer> createPubsubContainer() {
             final PubSubEmulatorContainer pubSubEmulatorContainer = new PubSubEmulatorContainer(
-                    DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators"));
+                    DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:583.0.0-emulators"));
 
             return new GenericContainerResource<>(pubSubEmulatorContainer, resource -> {
                 setUpEmulator(pubSubEmulatorContainer);


### PR DESCRIPTION
## What

`CamelGooglePubsubITest` pinned `gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators`. **That tag no longer exists on gcr.io**, so the test fails at class initialisation:

```
ContainerFetchException: Can't get Docker image: RemoteDockerImage(
    imageName=gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators, ...)
Caused by: NotFoundException: Status 404:
  {"message":"manifest for ...:441.0.0-emulators not found: manifest unknown"}
```

## This is not a per-branch problem

`main` has been red since 2026-08-27 and every open PR fails identically, on both Java 17 and Java 21, because surefire aborts the reactor on it. The three most recent `main` runs — the merges of #737, #739 and #707 — all failed with this same `CamelGooglePubsubITest.initializationError` and nothing else.

It is the only `gcr.io` image in the tree. The other testcontainers pins (`localstack`, `influxdb`, `confluentinc/cp-kafka`, `rabbitmq`, Debezium) are Docker Hub images and are unaffected.

## Why it happened, and why it will happen again

gcr.io keeps only a **rolling window** of `google-cloud-cli` tags — currently 49, from `537.0.0-emulators` up — and deletes older ones outright rather than archiving them. `441.0.0` aged out of that window.

Moved to `583.0.0-emulators`, the newest available, which buys the most time before the next eviction, with a comment at the call site explaining the failure mode so the next person does not have to re-derive it from a 404.

I did not use the floating `emulators` tag. It would never 404, but it would make the build non-reproducible and let the emulator change underneath us, which is the opposite of the direction #731 took the build.

## Verified, not assumed

- `docker pull ...:441.0.0-emulators` → `not found`
- `docker pull ...:583.0.0-emulators` → pulls, `sha256:07e4b8c3075ca793552fcfaf4808f104ef155d7805d87ade8e01b440463be262`
- the registry tag list confirms 49 `-emulators` tags, `441.0.0-emulators` absent
- **the test itself passes locally against the new image**, so the emulator API is still compatible across the 142 releases in between:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.07 s
  -- in org.apache.karaf.camel.itest.CamelGooglePubsubITest
BUILD SUCCESS
```

## Note

Worth considering separately whether these itests should fail soft when an external image cannot be fetched, so that an upstream registry change degrades one module instead of taking down every build in the project.

---
_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUwMcSUX951L1pqhiGkC6g
