### PR TITLE
fix(#748): bump the Pub/Sub emulator image on 4.18.x to a tag gcr.io still serves

### DIFF
--- a/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
+++ b/tests/features/camel-google-pubsub/src/test/java/org/apache/karaf/camel/itest/CamelGooglePubsubITest.java
@@ -64,9 +64,15 @@ public class CamelGooglePubsubITest extends AbstractCamelSingleFeatureResultMock
         static final String TEST_TOPIC = "test-topic";
         static final String TEST_SUBSCRIPTION = "test-subscription";
 
+        // gcr.io only retains a rolling window of the most recent google-cloud-cli emulator tags
+        // (~49 at the time of writing), so an exact pin eventually stops resolving and the itest
+        // fails with "manifest unknown". Bump this to a current tag when that happens.
+        private static final String PUB_SUB_EMULATOR_IMAGE
+                = "gcr.io/google.com/cloudsdktool/google-cloud-cli:583.0.0-emulators";
+
         public static GenericContainerResource<PubSubEmulatorContainer> createPubsubContainer() {
             final PubSubEmulatorContainer pubSubEmulatorContainer = new PubSubEmulatorContainer(
-                    DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators"));
+                    DockerImageName.parse(PUB_SUB_EMULATOR_IMAGE));
 
             return new GenericContainerResource<>(pubSubEmulatorContainer, resource -> {
                 setUpEmulator(pubSubEmulatorContainer);


### PR DESCRIPTION
Fixes #748. Backport of #746 to `camel-karaf-4.18.x`.

`CamelGooglePubsubITest` on this branch still pins
`gcr.io/google.com/cloudsdktool/google-cloud-cli:441.0.0-emulators`. `gcr.io`
keeps only a rolling window of the most recent `google-cloud-cli` emulator
tags, so that pin has stopped resolving.

Testcontainers then fails the container fetch with "manifest unknown", the
itest errors out in `initializationError`, and the Maven reactor halts at
`camel-google-pubsub-test`, skipping every later module — the same failure
#746 fixed on `main`.

This is currently blocking meaningful CI on the 4.18.x line, including
PR #742 (Upgrade to Camel 4.18.4), whose CI cannot be re-run and trusted until
this lands.

### Timing note

The tag was still being served recently: PR #742's CI run on 2026-08-28 pulled
`441.0.0-emulators` successfully (410 MB in the log). So this had not yet begun
failing on 4.18.x at that point — it is failing now.

### Change

The commit is a verbatim cherry-pick of #746's single-file change: extract the
image into a `PUB_SUB_EMULATOR_IMAGE` constant at `583.0.0-emulators`, and keep
the comment recording the registry retention behaviour so the next bump is not
a mystery.

The other four pinned test images (cp-kafka, influxdb, localstack, rabbitmq)
are untouched, as in #746.

### Verification

CI is the gate here. I could not run `CamelGooglePubsubITest` locally — no
Docker daemon available in my environment — so the Testcontainers path is
unverified on my side. The change is identical to the one already green on
`main`.

---

_Opened by an AI agent operated by JB Onofré._
